### PR TITLE
feat: add editable chord slots and responsive styles

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -6,7 +6,7 @@ Convenciones: [ ] pendiente · [x] hecho
 0. Lineamientos Técnicos Generales
    [x] Vite + TypeScript + HTML/CSS; ESLint+Prettier; TS strict; arquitectura modular; Vitest+Playwright.
    0B) Documentación
-   [ ] README con instrucciones básicas.
+   [x] README con instrucciones básicas.
 
 1. Inicialización
    [x] Proyecto Vite TS + CI.
@@ -20,10 +20,11 @@ Convenciones: [ ] pendiente · [x] hecho
 4. UI Base
    [x] Encabezado, riel, grid de compases, controles.
    4B) Estilos responsivos
-   [ ] CSS responsive mínimo.
+   [x] CSS responsive mínimo.
 
 5. Edición 4 acordes/compás
-   [ ] Slots 1–4 contenteditable; atajos; copiar/pegar.
+   [x] Slots 1–4 contenteditable.
+   [ ] Atajos; copiar/pegar.
 
 6. Renglón secundario
    [ ] Por beat; estilo pequeño; persistencia/imprimir.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# JaiReal-PRO
+
+Editor de cifrados orientado a trabajo offline.
+
+## Requisitos
+
+- Node.js 18+
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Desarrollo
+
+```bash
+npm run dev
+```
+
+Visita <http://localhost:5173> en tu navegador.
+
+## Pruebas
+
+```bash
+npm test
+npm run test:e2e
+```
+
+## Lint
+
+```bash
+npm run lint
+```

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,19 @@
-import { Chart, emptyChart } from '../core/model';
+import { Chart, schemaVersion } from '../core/model';
 
 const STORAGE_KEY = 'jaireal.chart';
+
+const demoChart = (): Chart => ({
+  schemaVersion,
+  title: 'Untitled',
+  sections: [
+    {
+      name: 'A',
+      measures: [
+        { beats: [{ chord: '' }, { chord: '' }, { chord: '' }, { chord: '' }] },
+      ],
+    },
+  ],
+});
 
 type Listener = () => void;
 
@@ -21,7 +34,7 @@ export class ChartStore {
     } catch {
       // ignore
     }
-    return emptyChart();
+    return demoChart();
   }
 
   private persist() {

--- a/src/style.css
+++ b/src/style.css
@@ -29,14 +29,38 @@ header {
   margin-bottom: 0.5rem;
 }
 
+
 .measure {
   border: 1px solid #888;
-  width: 4rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  width: 8rem;
   height: 4rem;
-  display: inline-block;
   margin-right: 0.25rem;
+}
+
+.slot {
+  border-right: 1px solid #888;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.slot:last-child {
+  border-right: none;
 }
 
 .controls {
   margin: 1rem;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    padding: 0.5rem;
+  }
+
+  .measure {
+    width: 100%;
+    height: 3rem;
+  }
 }

--- a/src/ui/components/Grid.ts
+++ b/src/ui/components/Grid.ts
@@ -14,9 +14,25 @@ export function Grid(): HTMLElement {
       title.textContent = section.name;
       sectionEl.appendChild(title);
 
-      section.measures.forEach(() => {
+      section.measures.forEach((measure) => {
         const measureEl = document.createElement('div');
         measureEl.className = 'measure';
+
+        for (let b = 0; b < 4; b++) {
+          if (!measure.beats[b]) {
+            measure.beats[b] = { chord: '' };
+          }
+          const slot = document.createElement('div');
+          slot.className = 'slot';
+          slot.contentEditable = 'true';
+          slot.textContent = measure.beats[b].chord;
+          slot.oninput = () => {
+            measure.beats[b].chord = slot.textContent || '';
+            store.setChart(store.chart);
+          };
+          measureEl.appendChild(slot);
+        }
+
         sectionEl.appendChild(measureEl);
       });
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -4,3 +4,12 @@ test('homepage has header', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('header')).toHaveText('JaiReal-PRO');
 });
+
+test('measure has four editable slots', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.measure .slot')).toHaveCount(4);
+  await expect(page.locator('.measure .slot').first()).toHaveAttribute(
+    'contenteditable',
+    'true',
+  );
+});


### PR DESCRIPTION
## Summary
- add README with basic setup instructions
- implement editable chord slots with default chart data
- add responsive CSS and slot styling

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ad11bca0588333b33ba71bac24c05a