### PR TITLE
feat: support secondary line editing with copy-paste shortcuts

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -24,10 +24,14 @@ Convenciones: [ ] pendiente · [x] hecho
 
 5. Edición 4 acordes/compás
    [x] Slots 1–4 contenteditable.
-   [ ] Atajos; copiar/pegar.
+   [x] Atajos; copiar/pegar.
+   5B) Copiar/pegar compases completos y portapapeles del sistema
+   [ ] Pendiente.
 
 6. Renglón secundario
-   [ ] Por beat; estilo pequeño; persistencia/imprimir.
+   [x] Por beat; estilo pequeño; persistencia.
+   6B) Imprimir renglón secundario
+   [ ] Pendiente.
 
 7. Marcadores
    [ ] %, ||:, :||, Segno/Coda/Fine/D.C./D.S./To Coda con toolbar y reglas.

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -12,4 +12,17 @@ describe('ChartStore', () => {
     const raw = localStorage.getItem('jaireal.chart');
     expect(raw).toBeTruthy();
   });
+
+  it('stores secondary line per beat', () => {
+    const s = new ChartStore();
+    s.setChart({
+      schemaVersion: 1,
+      title: 't',
+      sections: [
+        { name: 'A', measures: [{ beats: [{ chord: 'C', secondary: 'b' }] }] },
+      ],
+    });
+    const s2 = new ChartStore();
+    expect(s2.chart.sections[0].measures[0].beats[0].secondary).toBe('b');
+  });
 });

--- a/src/style.css
+++ b/src/style.css
@@ -42,8 +42,19 @@ header {
 .slot {
   border-right: 1px solid #888;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+}
+
+.chord {
+  line-height: 1.2;
+}
+
+.secondary {
+  font-size: 0.7em;
+  line-height: 1;
+  color: #555;
 }
 
 .slot:last-child {

--- a/src/ui/components/Grid.ts
+++ b/src/ui/components/Grid.ts
@@ -1,4 +1,7 @@
 import { store } from '../../state/store';
+import type { BeatSlot } from '../../core/model';
+
+let clipboard: BeatSlot | null = null;
 
 export function Grid(): HTMLElement {
   const el = document.createElement('div');
@@ -22,14 +25,50 @@ export function Grid(): HTMLElement {
           if (!measure.beats[b]) {
             measure.beats[b] = { chord: '' };
           }
+          const beat = measure.beats[b];
           const slot = document.createElement('div');
           slot.className = 'slot';
-          slot.contentEditable = 'true';
-          slot.textContent = measure.beats[b].chord;
-          slot.oninput = () => {
-            measure.beats[b].chord = slot.textContent || '';
+
+          const chordEl = document.createElement('div');
+          chordEl.className = 'chord';
+          chordEl.contentEditable = 'true';
+          chordEl.textContent = beat.chord;
+          chordEl.oninput = () => {
+            beat.chord = chordEl.textContent || '';
             store.setChart(store.chart);
           };
+
+          const secondaryEl = document.createElement('div');
+          secondaryEl.className = 'secondary';
+          secondaryEl.contentEditable = 'true';
+          secondaryEl.textContent = beat.secondary || '';
+          secondaryEl.oninput = () => {
+            beat.secondary = secondaryEl.textContent || '';
+            store.setChart(store.chart);
+          };
+
+          const handleKey = (ev: KeyboardEvent) => {
+            if (ev.ctrlKey && ev.shiftKey && ev.key === 'c') {
+              clipboard = { chord: beat.chord, secondary: beat.secondary };
+              ev.preventDefault();
+            }
+            if (ev.ctrlKey && ev.shiftKey && ev.key === 'v') {
+              if (clipboard) {
+                beat.chord = clipboard.chord;
+                beat.secondary = clipboard.secondary;
+                chordEl.textContent = beat.chord;
+                secondaryEl.textContent = beat.secondary || '';
+                store.setChart(store.chart);
+              }
+              ev.preventDefault();
+            }
+          };
+
+          chordEl.addEventListener('keydown', handleKey);
+          secondaryEl.addEventListener('keydown', handleKey);
+
+          slot.appendChild(chordEl);
+          slot.appendChild(secondaryEl);
           measureEl.appendChild(slot);
         }
 


### PR DESCRIPTION
## Summary
- add per-beat secondary line with persistent storage
- enable chord copy/paste via Ctrl+Shift+C/V
- track completed tasks and create follow-up items

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5beff514833382ea71fa64675ce1