### PR TITLE
feat: toggle secondary line and drag indicator

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -30,13 +30,15 @@ Convenciones: [ ] pendiente · [x] hecho
    5C) Arrastrar para reordenar compases
    [x] Hecho.
    5D) Indicador visual al arrastrar compases
-   [ ] Pendiente.
+   [x] Hecho.
 
 6. Renglón secundario
    [x] Por beat; estilo pequeño; persistencia.
    6B) Imprimir renglón secundario
    [x] Hecho.
    6C) Toggle de visibilidad del renglón secundario
+   [x] Hecho.
+   6D) Atajo de teclado para alternar renglón secundario
    [ ] Pendiente.
 
 7. Marcadores

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -25,4 +25,13 @@ describe('ChartStore', () => {
     const s2 = new ChartStore();
     expect(s2.chart.sections[0].measures[0].beats[0].secondary).toBe('b');
   });
+
+  it('toggles and persists secondary visibility', () => {
+    const s = new ChartStore();
+    expect(s.showSecondary).toBe(true);
+    s.toggleSecondary();
+    expect(s.showSecondary).toBe(false);
+    const s2 = new ChartStore();
+    expect(s2.showSecondary).toBe(false);
+  });
 });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,7 @@
 import { Chart, schemaVersion } from '../core/model';
 
 const STORAGE_KEY = 'jaireal.chart';
+const SHOW_SECONDARY_KEY = 'jaireal.showSecondary';
 
 const demoChart = (): Chart => ({
   schemaVersion,
@@ -19,13 +20,15 @@ type Listener = () => void;
 
 export class ChartStore {
   chart: Chart;
+  showSecondary: boolean;
   private listeners: Set<Listener> = new Set();
 
   constructor() {
-    this.chart = this.load();
+    this.chart = this.loadChart();
+    this.showSecondary = this.loadShowSecondary();
   }
 
-  private load(): Chart {
+  private loadChart(): Chart {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       if (raw) {
@@ -41,6 +44,25 @@ export class ChartStore {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(this.chart));
   }
 
+  private loadShowSecondary(): boolean {
+    try {
+      const raw = localStorage.getItem(SHOW_SECONDARY_KEY);
+      if (raw !== null) {
+        return JSON.parse(raw) as boolean;
+      }
+    } catch {
+      // ignore
+    }
+    return true;
+  }
+
+  private persistShowSecondary() {
+    localStorage.setItem(
+      SHOW_SECONDARY_KEY,
+      JSON.stringify(this.showSecondary),
+    );
+  }
+
   subscribe(listener: Listener) {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
@@ -49,6 +71,12 @@ export class ChartStore {
   setChart(chart: Chart) {
     this.chart = chart;
     this.persist();
+    this.listeners.forEach((l) => l());
+  }
+
+  toggleSecondary() {
+    this.showSecondary = !this.showSecondary;
+    this.persistShowSecondary();
     this.listeners.forEach((l) => l());
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -29,7 +29,6 @@ header {
   margin-bottom: 0.5rem;
 }
 
-
 .measure {
   border: 1px solid #888;
   display: grid;
@@ -37,6 +36,10 @@ header {
   width: 8rem;
   height: 4rem;
   margin-right: 0.25rem;
+}
+
+.measure.drag-over {
+  border-color: #00f;
 }
 
 .slot {

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -28,6 +28,18 @@ export function Controls(): HTMLElement {
     }
   };
 
-  el.append(saveBtn, loadInput);
+  const toggleSecondaryBtn = document.createElement('button');
+  const updateToggleText = () => {
+    toggleSecondaryBtn.textContent = store.showSecondary
+      ? 'Ocultar renglón secundario'
+      : 'Mostrar renglón secundario';
+  };
+  updateToggleText();
+  toggleSecondaryBtn.onclick = () => {
+    store.toggleSecondary();
+    updateToggleText();
+  };
+
+  el.append(saveBtn, loadInput, toggleSecondaryBtn);
   return el;
 }

--- a/src/ui/components/Grid.ts
+++ b/src/ui/components/Grid.ts
@@ -34,8 +34,15 @@ export function Grid(): HTMLElement {
           ev.preventDefault();
           ev.dataTransfer!.dropEffect = 'move';
         });
+        measureEl.addEventListener('dragenter', () => {
+          measureEl.classList.add('drag-over');
+        });
+        measureEl.addEventListener('dragleave', () => {
+          measureEl.classList.remove('drag-over');
+        });
         measureEl.addEventListener('drop', (ev) => {
           ev.preventDefault();
+          measureEl.classList.remove('drag-over');
           if (dragSection === sIdx && dragIndex !== null) {
             const measures = section.measures;
             const [m] = measures.splice(dragIndex, 1);
@@ -69,6 +76,7 @@ export function Grid(): HTMLElement {
           secondaryEl.className = 'secondary';
           secondaryEl.contentEditable = 'true';
           secondaryEl.textContent = beat.secondary || '';
+          secondaryEl.style.display = store.showSecondary ? '' : 'none';
           secondaryEl.oninput = () => {
             beat.secondary = secondaryEl.textContent || '';
             store.setChart(store.chart);


### PR DESCRIPTION
## Summary
- toggle secondary line visibility with persisted setting
- highlight measures while dragging
- document completed and new tasks in roadmap

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad5f299cf08333b15fb821b0ffd7ff