### PR TITLE
feat: validate marker rules

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -46,6 +46,8 @@ Convenciones: [ ] pendiente · [x] hecho
 7. Marcadores
    [x] %, ||:, :||, Segno/Coda/Fine/D.C./D.S./To Coda con toolbar y reglas.
    7B) Validaciones y reglas de marcadores
+   [x] Hecho.
+   7C) Mensajes de error de validación en la UI
    [ ] Pendiente.
 
 8. Voltas

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -64,4 +64,46 @@ describe('ChartStore', () => {
     s.setMarker('');
     expect(s.chart.sections[0].measures[0].markers).toBeUndefined();
   });
+
+  it('validates marker dependencies', () => {
+    const s = new ChartStore();
+    s.setChart({
+      schemaVersion: 1,
+      title: 't',
+      sections: [
+        {
+          name: 'A',
+          measures: [{ beats: [{ chord: 'C' }] }, { beats: [{ chord: 'D' }] }],
+        },
+      ],
+    });
+    s.selectMeasure(0, 0);
+    expect(s.setMarker('D.S.')).toBe(false);
+    expect(s.chart.sections[0].measures[0].markers).toBeUndefined();
+
+    s.selectMeasure(0, 1);
+    expect(s.setMarker('Segno')).toBe(true);
+
+    s.selectMeasure(0, 0);
+    expect(s.setMarker('D.S.')).toBe(true);
+  });
+
+  it('ensures single occurrence markers', () => {
+    const s = new ChartStore();
+    s.setChart({
+      schemaVersion: 1,
+      title: 't',
+      sections: [
+        {
+          name: 'A',
+          measures: [{ beats: [{ chord: 'C' }] }, { beats: [{ chord: 'D' }] }],
+        },
+      ],
+    });
+    s.selectMeasure(0, 0);
+    expect(s.setMarker('Coda')).toBe(true);
+    s.selectMeasure(0, 1);
+    expect(s.setMarker('Coda')).toBe(false);
+    expect(s.chart.sections[0].measures[1].markers).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add validation and notification logic for chart markers
- cover marker rules with new tests
- mark marker validation task as complete and add follow-up UI task

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6266d6348333ba828704cb0540b7