### PR TITLE
feat: display marker validation errors

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -48,6 +48,8 @@ Convenciones: [ ] pendiente · [x] hecho
    7B) Validaciones y reglas de marcadores
    [x] Hecho.
    7C) Mensajes de error de validación en la UI
+   [x] Hecho.
+   7D) Botón para cerrar mensajes de error manualmente
    [ ] Pendiente.
 
 8. Voltas

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -106,4 +106,20 @@ describe('ChartStore', () => {
     expect(s.setMarker('Coda')).toBe(false);
     expect(s.chart.sections[0].measures[1].markers).toBeUndefined();
   });
+
+  it('notifies on invalid markers', () => {
+    const s = new ChartStore();
+    let msg = '';
+    s.onMessage((m) => {
+      msg = m;
+    });
+    s.setChart({
+      schemaVersion: 1,
+      title: 't',
+      sections: [{ name: 'A', measures: [{ beats: [{ chord: 'C' }] }] }],
+    });
+    s.selectMeasure(0, 0);
+    s.setMarker('D.S.');
+    expect(msg).toBe('D.S. requiere un Segno.');
+  });
 });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -29,6 +29,7 @@ export class ChartStore {
   selectedSection: number | null = null;
   selectedMeasure: number | null = null;
   private listeners: Set<Listener> = new Set();
+  private messageListeners: Set<(msg: string) => void> = new Set();
 
   constructor() {
     this.chart = this.loadChart();
@@ -75,6 +76,11 @@ export class ChartStore {
     return () => this.listeners.delete(listener);
   }
 
+  onMessage(listener: (msg: string) => void) {
+    this.messageListeners.add(listener);
+    return () => this.messageListeners.delete(listener);
+  }
+
   setChart(chart: Chart) {
     this.chart = chart;
     this.persist();
@@ -112,6 +118,10 @@ export class ChartStore {
   }
 
   private notify(message: string) {
+    if (this.messageListeners.size) {
+      this.messageListeners.forEach((l) => l(message));
+      return;
+    }
     if (
       typeof window !== 'undefined' &&
       typeof window.alert === 'function' &&

--- a/src/style.css
+++ b/src/style.css
@@ -82,6 +82,12 @@ header {
   margin: 1rem;
 }
 
+.message {
+  color: #c00;
+  margin-top: 0.5rem;
+  display: none;
+}
+
 @media (max-width: 600px) {
   .grid {
     padding: 0.5rem;

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -5,6 +5,9 @@ export function Controls(): HTMLElement {
   const el = document.createElement('div');
   el.className = 'controls';
 
+  const messageEl = document.createElement('div');
+  messageEl.className = 'message';
+
   const saveBtn = document.createElement('button');
   saveBtn.textContent = 'Guardar JSON';
   saveBtn.onclick = () => {
@@ -80,6 +83,15 @@ export function Controls(): HTMLElement {
     store.setMarker(markerSelect.value as Marker | '');
   };
 
+  store.onMessage((msg) => {
+    messageEl.textContent = msg;
+    messageEl.style.display = 'block';
+    setTimeout(() => {
+      messageEl.textContent = '';
+      messageEl.style.display = 'none';
+    }, 3000);
+  });
+
   store.subscribe(() => {
     updateToggleText();
     updateMarkerSelect();
@@ -87,6 +99,6 @@ export function Controls(): HTMLElement {
   updateMarkerSelect();
 
   markerLabel.appendChild(markerSelect);
-  el.append(saveBtn, loadInput, toggleSecondaryBtn, markerLabel);
+  el.append(saveBtn, loadInput, toggleSecondaryBtn, markerLabel, messageEl);
   return el;
 }


### PR DESCRIPTION
## Summary
- show marker validation issues inline in controls
- expose ChartStore onMessage subscription
- document completion of marker validation messages task

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad6414438483339654a032f2cb3ddf