### PR TITLE
test: add error message e2e test

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -52,6 +52,8 @@ Convenciones: [ ] pendiente · [x] hecho
    7D) Botón para cerrar mensajes de error manualmente
    [x] Hecho.
    7E) Pruebas automáticas para el botón de cierre
+   [x] Hecho.
+   7F) Accesibilidad del mensaje (foco y ARIA)
    [ ] Pendiente.
 
 8. Voltas

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test';
 
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('jaireal.showSecondary', 'true');
+  });
+});
+
 test('homepage has header', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('header')).toHaveText('JaiReal-PRO');
@@ -8,7 +15,7 @@ test('homepage has header', async ({ page }) => {
 test('measure has four editable slots', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('.measure .slot')).toHaveCount(4);
-  await expect(page.locator('.measure .slot').first()).toHaveAttribute(
+  await expect(page.locator('.measure .chord').first()).toHaveAttribute(
     'contenteditable',
     'true',
   );
@@ -16,10 +23,11 @@ test('measure has four editable slots', async ({ page }) => {
 
 test('toggle secondary line with keyboard shortcut', async ({ page }) => {
   await page.goto('/');
+  await page.click('body');
   const secondary = page.locator('.secondary').first();
-  await expect(secondary).toBeVisible();
+  await expect(secondary).toHaveCSS('display', 'block');
   await page.keyboard.press('Control+Shift+L');
-  await expect(secondary).toBeHidden();
+  await expect(secondary).toHaveCSS('display', 'none');
   await page.keyboard.press('Control+Shift+L');
-  await expect(secondary).toBeVisible();
+  await expect(secondary).toHaveCSS('display', 'block');
 });

--- a/tests/message.spec.ts
+++ b/tests/message.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('close marker validation message manually', async ({ page }) => {
+  await page.goto('/');
+  // Select first measure to enable marker selection
+  await page.click('.measure');
+  // Choose an invalid marker (Fine requires D.C. or D.S.)
+  await page.selectOption('select', 'Fine');
+  const message = page.locator('.message');
+  await expect(message).toBeVisible();
+  await expect(message).toContainText('Fine requiere D.C. o D.S.');
+  await page.click('.message-close');
+  await expect(message).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- add Playwright test covering error message dismissal
- stabilize existing e2e tests and reset local storage
- mark marker message test as done and note accessibility follow-up

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ad6629a5108333bf82d9379da40cd3