### PR TITLE
feat: improve accessibility of marker validation message

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -54,6 +54,8 @@ Convenciones: [ ] pendiente · [x] hecho
    7E) Pruebas automáticas para el botón de cierre
    [x] Hecho.
    7F) Accesibilidad del mensaje (foco y ARIA)
+   [x] Hecho.
+   7G) Restaurar foco al elemento activador al cerrar el mensaje
    [ ] Pendiente.
 
 8. Voltas

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -8,11 +8,14 @@ export function Controls(): HTMLElement {
   const messageEl = document.createElement('div');
   messageEl.className = 'message';
   messageEl.setAttribute('role', 'alert');
+  messageEl.setAttribute('aria-live', 'assertive');
+  messageEl.tabIndex = -1;
   const messageText = document.createElement('span');
   const closeBtn = document.createElement('button');
   closeBtn.className = 'message-close';
   closeBtn.type = 'button';
   closeBtn.textContent = '×';
+  closeBtn.setAttribute('aria-label', 'Cerrar mensaje');
   messageEl.append(messageText, closeBtn);
 
   let hideTimeout: number | undefined;
@@ -104,6 +107,7 @@ export function Controls(): HTMLElement {
   store.onMessage((msg) => {
     messageText.textContent = msg;
     messageEl.style.display = 'flex';
+    messageEl.focus();
     hideTimeout = window.setTimeout(() => {
       hideMessage();
     }, 3000);

--- a/tests/message.spec.ts
+++ b/tests/message.spec.ts
@@ -9,6 +9,9 @@ test('close marker validation message manually', async ({ page }) => {
   const message = page.locator('.message');
   await expect(message).toBeVisible();
   await expect(message).toContainText('Fine requiere D.C. o D.S.');
+  await expect(message).toBeFocused();
+  await expect(message).toHaveAttribute('role', 'alert');
+  await expect(message).toHaveAttribute('aria-live', 'assertive');
   await page.click('.message-close');
   await expect(message).toBeHidden();
 });


### PR DESCRIPTION
## Summary
- announce validation messages with aria-live and focus
- label close button for screen readers and add tests
- mark task 7F as done and add follow-up task for focus restoration

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ad68fbe8dc8333a846fdc56214e6dd