### PR TITLE
feat: add instrument views with accidental preference

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -65,7 +65,10 @@ Convenciones: [ ] pendiente · [x] hecho
    9A) Semitonos sobre toda la partitura
    [x] Hecho.
    9B) Vistas Concierto/Bb/Eb/F y preferencia ♯/♭
-   [ ] Pendiente.
+   [x] Hecho.
+
+9C) Sincronizar botones de transposición manual con vista de instrumento
+[ ] Pendiente.
 
 10. Plantillas
     [ ] AABA/Blues/Rhythm Changes/Intro-Tag-Out.

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -150,4 +150,47 @@ describe('ChartStore', () => {
     expect(beats[1].chord).toBe('G#');
     expect(beats[1].secondary).toBe('A');
   });
+
+  it('sets instrument views and accidental preference', () => {
+    const s = new ChartStore();
+    s.setChart({
+      schemaVersion: 1,
+      title: 't',
+      sections: [
+        {
+          name: 'A',
+          measures: [
+            {
+              beats: [
+                { chord: 'C' },
+                { chord: 'Db' },
+                { chord: '', secondary: '' },
+                { chord: '' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    s.setInstrument('Bb');
+    let beats = s.chart.sections[0].measures[0].beats;
+    expect(beats[0].chord).toBe('D');
+    expect(beats[1].chord).toBe('D#');
+
+    s.setInstrument('Bb', false);
+    beats = s.chart.sections[0].measures[0].beats;
+    expect(beats[1].chord).toBe('Eb');
+
+    s.setInstrument('C');
+    beats = s.chart.sections[0].measures[0].beats;
+    expect(beats[0].chord).toBe('C');
+  });
+
+  it('persists instrument settings', () => {
+    const s = new ChartStore();
+    s.setInstrument('Eb', false);
+    const s2 = new ChartStore();
+    expect(s2.instrument).toBe('Eb');
+    expect(s2.preferSharps).toBe(false);
+  });
 });

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -86,6 +86,53 @@ export function Controls(): HTMLElement {
     store.transpose(-1);
   };
 
+  const instrumentLabel = document.createElement('label');
+  instrumentLabel.textContent = 'Vista: ';
+  const instrumentSelect = document.createElement('select');
+  [
+    ['C', 'Concierto'],
+    ['Bb', 'Bb'],
+    ['Eb', 'Eb'],
+    ['F', 'F'],
+  ].forEach(([value, text]) => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = text;
+    instrumentSelect.appendChild(opt);
+  });
+
+  const accidentalLabel = document.createElement('label');
+  accidentalLabel.textContent = 'Preferir: ';
+  const accidentalSelect = document.createElement('select');
+  [
+    ['sharp', '♯'],
+    ['flat', '♭'],
+  ].forEach(([value, text]) => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = text;
+    accidentalSelect.appendChild(opt);
+  });
+
+  const updateViewControls = () => {
+    instrumentSelect.value = store.instrument;
+    accidentalSelect.value = store.preferSharps ? 'sharp' : 'flat';
+  };
+  updateViewControls();
+
+  instrumentSelect.onchange = () => {
+    store.setInstrument(
+      instrumentSelect.value as 'C' | 'Bb' | 'Eb' | 'F',
+      accidentalSelect.value === 'sharp',
+    );
+  };
+  accidentalSelect.onchange = () => {
+    store.setInstrument(
+      instrumentSelect.value as 'C' | 'Bb' | 'Eb' | 'F',
+      accidentalSelect.value === 'sharp',
+    );
+  };
+
   const markerLabel = document.createElement('label');
   markerLabel.textContent = 'Marcador: ';
   const markerSelect = document.createElement('select');
@@ -137,6 +184,7 @@ export function Controls(): HTMLElement {
   store.subscribe(() => {
     updateToggleText();
     updateMarkerSelect();
+    updateViewControls();
   });
   updateMarkerSelect();
 
@@ -147,6 +195,10 @@ export function Controls(): HTMLElement {
     toggleSecondaryBtn,
     transposeUpBtn,
     transposeDownBtn,
+    instrumentLabel,
+    instrumentSelect,
+    accidentalLabel,
+    accidentalSelect,
     markerLabel,
     messageEl,
   );


### PR DESCRIPTION
## Summary
- add instrument view modes (Concert, Bb, Eb, F) with sharps/flats preference
- persist selected view in local storage
- expose controls and tests for instrument transposition

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6d83bd988333859627acb70ed2d6