### PR TITLE
feat: show octave transpose shortcuts

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -82,7 +82,7 @@ Convenciones: [ ] pendiente · [x] hecho
 [x] Hecho.
 
 9I) Mostrar atajos de octava en la interfaz
-[ ] Pendiente.
+[x] Hecho.
 
 10. Plantillas
     [ ] AABA/Blues/Rhythm Changes/Intro-Tag-Out.
@@ -147,3 +147,6 @@ Criterios de aceptación (15B)
     [ ] MVP: 1–8,10,11(PDF),12(min),15(PWA),17 parcial,18.
     [ ] v1: 9,11(PNG/SVG),13,14,15B (sync+share lectura),16,17 completo.
     [ ] v2: colaboración tiempo real, LMS, lote PDF/ZIP, diffs y merge por compás.
+
+20. Audio
+    [ ] Reproducción de acordes con Web Audio API.

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -77,7 +77,7 @@ export function Controls(): HTMLElement {
   const transposeUpBtn = document.createElement('button');
   const transposeUpShortcut = 'Ctrl+↑';
   const transposeOctUpShortcut = 'Ctrl+Alt+↑';
-  transposeUpBtn.textContent = `Transponer +1 (${transposeUpShortcut})`;
+  transposeUpBtn.textContent = `Transponer +1 (${transposeUpShortcut}) / +12 (${transposeOctUpShortcut})`;
   transposeUpBtn.title = `${transposeUpShortcut} (+1), ${transposeOctUpShortcut} (+12)`;
   transposeUpBtn.onclick = () => {
     store.transpose(1);
@@ -86,7 +86,7 @@ export function Controls(): HTMLElement {
   const transposeDownBtn = document.createElement('button');
   const transposeDownShortcut = 'Ctrl+↓';
   const transposeOctDownShortcut = 'Ctrl+Alt+↓';
-  transposeDownBtn.textContent = `Transponer -1 (${transposeDownShortcut})`;
+  transposeDownBtn.textContent = `Transponer -1 (${transposeDownShortcut}) / -12 (${transposeOctDownShortcut})`;
   transposeDownBtn.title = `${transposeDownShortcut} (-1), ${transposeOctDownShortcut} (-12)`;
   transposeDownBtn.onclick = () => {
     store.transpose(-1);

--- a/tests/transpose-octave-ui.spec.ts
+++ b/tests/transpose-octave-ui.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => {
+    window.localStorage.clear();
+  });
+});
+
+test('shows octave transpose shortcuts in controls', async ({ page }) => {
+  await page.goto('/');
+  await expect(
+    page.getByRole('button', { name: /Ctrl\+Alt\+↑/ }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /Ctrl\+Alt\+↓/ }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- display octave transpose keyboard shortcuts in transpose buttons
- track completion of octave shortcut task and add audio playback TODO
- cover octave shortcut hints with Playwright test

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68adb8efa0808333b34a84f323cf6147