### PR TITLE
feat(audio): add chord playback

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -149,4 +149,6 @@ Criterios de aceptación (15B)
     [ ] v2: colaboración tiempo real, LMS, lote PDF/ZIP, diffs y merge por compás.
 
 20. Audio
-    [ ] Reproducción de acordes con Web Audio API.
+    [x] Reproducción de acordes con Web Audio API.
+    20B) Control de tempo y parada
+    [ ] Ajustar BPM y botón de detener reproducción.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JaiReal-PRO
 
 Editor de cifrados orientado a trabajo offline.
+Incluye reproducción básica de acordes con la Web Audio API.
 
 ## Requisitos
 

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -1,0 +1,93 @@
+import type { Chart } from '../core/model';
+
+let audioCtx: AudioContext | null = null;
+function getCtx(): AudioContext {
+  if (!audioCtx) {
+    if (typeof window === 'undefined') {
+      throw new Error('Web Audio API no disponible');
+    }
+    const AC = (window.AudioContext ||
+      (window as unknown as { webkitAudioContext: typeof AudioContext })
+        .webkitAudioContext) as typeof AudioContext;
+    audioCtx = new AC();
+  }
+  return audioCtx;
+}
+
+const noteFreq: Record<string, number> = {
+  C: 261.63,
+  'C#': 277.18,
+  Db: 277.18,
+  D: 293.66,
+  'D#': 311.13,
+  Eb: 311.13,
+  E: 329.63,
+  F: 349.23,
+  'F#': 369.99,
+  Gb: 369.99,
+  G: 392.0,
+  'G#': 415.3,
+  Ab: 415.3,
+  A: 440.0,
+  'A#': 466.16,
+  Bb: 466.16,
+  B: 493.88,
+};
+
+function parseChord(chord: string): number[] {
+  const match = chord.match(/^([A-G](?:#|b)?)(.*)$/);
+  if (!match) return [];
+  const [, root, rest] = match;
+  const base = noteFreq[root];
+  if (!base) return [];
+  const intervals: number[] = [0];
+  const minor = /^m(?!aj)/i.test(rest);
+  intervals.push(minor ? 3 : 4); // third
+  intervals.push(7); // fifth
+  if (/7/.test(rest)) intervals.push(10); // seventh
+  return intervals.map((i) => base * 2 ** (i / 12));
+}
+
+function scheduleChord(freqs: number[], start: number, duration: number) {
+  const ctx = getCtx();
+  freqs.forEach((f) => {
+    const osc = ctx.createOscillator();
+    osc.type = 'sine';
+    osc.frequency.value = f;
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    const t = ctx.currentTime + start;
+    const end = t + duration;
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.exponentialRampToValueAtTime(0.5, t + 0.05);
+    gain.gain.exponentialRampToValueAtTime(0.0001, end);
+    osc.start(t);
+    osc.stop(end);
+  });
+}
+
+export function playChart(chart: Chart, tempo = 120) {
+  const ctx = getCtx();
+  if (ctx.state === 'suspended') void ctx.resume();
+  const beatDur = 60 / tempo;
+  let time = 0;
+  chart.sections.forEach((section) => {
+    section.measures.forEach((m) => {
+      m.beats.forEach((b) => {
+        if (b.chord) {
+          const freqs = parseChord(b.chord);
+          if (freqs.length) scheduleChord(freqs, time, beatDur);
+        }
+        time += beatDur;
+      });
+    });
+  });
+}
+
+export function stopPlayback() {
+  if (audioCtx) {
+    audioCtx.close();
+    audioCtx = null;
+  }
+}

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -1,10 +1,10 @@
 import { store } from '../../state/store';
 import type { Marker } from '../../core/model';
+import { playChart, stopPlayback } from '../../audio/player';
 
 export function Controls(): HTMLElement {
   const el = document.createElement('div');
   el.className = 'controls';
-
   const messageEl = document.createElement('div');
   messageEl.className = 'message';
   messageEl.setAttribute('role', 'alert');
@@ -104,6 +104,18 @@ export function Controls(): HTMLElement {
   resetTransposeBtn.textContent = 'Reset Transposición';
   resetTransposeBtn.onclick = () => {
     store.resetTranspose();
+  };
+
+  const playBtn = document.createElement('button');
+  playBtn.textContent = 'Reproducir';
+  playBtn.onclick = () => {
+    playChart(store.chart);
+  };
+
+  const stopBtn = document.createElement('button');
+  stopBtn.textContent = 'Detener';
+  stopBtn.onclick = () => {
+    stopPlayback();
   };
 
   const instrumentLabel = document.createElement('label');
@@ -218,6 +230,8 @@ export function Controls(): HTMLElement {
     transposeDownBtn,
     transposeInfo,
     resetTransposeBtn,
+    playBtn,
+    stopBtn,
     instrumentLabel,
     instrumentSelect,
     accidentalLabel,


### PR DESCRIPTION
## Summary
- add Web Audio API chord playback with basic triads
- expose play and stop controls in the UI
- document audio feature and update task list

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbb0ac5608333991d8c489a69bc14