### PR TITLE
feat: add tempo control to playback

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -151,4 +151,6 @@ Criterios de aceptación (15B)
 20. Audio
     [x] Reproducción de acordes con Web Audio API.
     20B) Control de tempo y parada
-    [ ] Ajustar BPM y botón de detener reproducción.
+    [x] Ajustar BPM y botón de detener reproducción.
+    20C) Metrónomo durante reproducción
+    [ ] Implementar clic de metrónomo sincronizado con el tempo.

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -10,6 +10,7 @@ const STORAGE_KEY = 'jaireal.chart';
 const SHOW_SECONDARY_KEY = 'jaireal.showSecondary';
 const VIEW_KEY = 'jaireal.view';
 const MANUAL_TRANSPOSE_KEY = 'jaireal.manualTranspose';
+const TEMPO_KEY = 'jaireal.tempo';
 
 type Instrument = 'C' | 'Bb' | 'Eb' | 'F';
 const instrumentSemitones: Record<Instrument, number> = {
@@ -40,6 +41,7 @@ export class ChartStore {
   instrument: Instrument;
   preferSharps: boolean;
   manualTranspose = 0;
+  tempo: number;
   selectedSection: number | null = null;
   selectedMeasure: number | null = null;
   private listeners: Set<Listener> = new Set();
@@ -52,6 +54,7 @@ export class ChartStore {
     this.instrument = view.instrument;
     this.preferSharps = view.preferSharps;
     this.manualTranspose = this.loadManualTranspose();
+    this.tempo = this.loadTempo();
   }
 
   private loadChart(): Chart {
@@ -112,6 +115,22 @@ export class ChartStore {
         preferSharps: this.preferSharps,
       }),
     );
+  }
+
+  private loadTempo(): number {
+    try {
+      const raw = localStorage.getItem(TEMPO_KEY);
+      if (raw) {
+        return JSON.parse(raw) as number;
+      }
+    } catch {
+      // ignore
+    }
+    return 120;
+  }
+
+  private persistTempo() {
+    localStorage.setItem(TEMPO_KEY, JSON.stringify(this.tempo));
   }
 
   private loadManualTranspose(): number {
@@ -209,6 +228,12 @@ export class ChartStore {
       this.persistManualTranspose();
       this.listeners.forEach((l) => l());
     }
+  }
+
+  setTempo(bpm: number) {
+    this.tempo = bpm;
+    this.persistTempo();
+    this.listeners.forEach((l) => l());
   }
 
   toJSON() {

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -106,10 +106,25 @@ export function Controls(): HTMLElement {
     store.resetTranspose();
   };
 
+  const tempoLabel = document.createElement('label');
+  tempoLabel.textContent = 'Tempo: ';
+  const tempoInput = document.createElement('input');
+  tempoInput.type = 'number';
+  tempoInput.min = '40';
+  tempoInput.max = '240';
+  tempoInput.value = String(store.tempo);
+  tempoInput.onchange = () => {
+    const val = Number(tempoInput.value);
+    if (!Number.isNaN(val)) {
+      store.setTempo(val);
+    }
+  };
+  tempoLabel.appendChild(tempoInput);
+
   const playBtn = document.createElement('button');
   playBtn.textContent = 'Reproducir';
   playBtn.onclick = () => {
-    playChart(store.chart);
+    playChart(store.chart, store.tempo);
   };
 
   const stopBtn = document.createElement('button');
@@ -218,6 +233,7 @@ export function Controls(): HTMLElement {
     updateMarkerSelect();
     updateViewControls();
     updateTransposeInfo();
+    tempoInput.value = String(store.tempo);
   });
   updateMarkerSelect();
 
@@ -230,6 +246,7 @@ export function Controls(): HTMLElement {
     transposeDownBtn,
     transposeInfo,
     resetTransposeBtn,
+    tempoLabel,
     playBtn,
     stopBtn,
     instrumentLabel,


### PR DESCRIPTION
## Summary
- persist user tempo in store and expose setter
- add tempo input to controls and pass bpm to player
- mark tempo control task complete and note metronome follow-up

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:e2e` *(fails: executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `curl -I https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_68adbce88e948333a91dc4fd0c903621