### PR TITLE
feat: add metronome toggle with persistence

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -155,4 +155,8 @@ Criterios de aceptación (15B)
     20C) Metrónomo durante reproducción
     [x] Implementar clic de metrónomo sincronizado con el tempo.
     20D) Toggle de metrónomo
-    [ ] Permitir activar o desactivar el sonido del metrónomo durante la reproducción.
+    [x] Permitir activar o desactivar el sonido del metrónomo durante la reproducción.
+    20E) Persistencia de preferencia de metrónomo
+    [x] Recordar si el metrónomo está activado entre sesiones.
+    20F) Control de volumen del metrónomo
+    [ ] Ajustar el volumen del clic del metrónomo.

--- a/src/audio/player.test.ts
+++ b/src/audio/player.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Chart } from '../core/model';
+import * as player from './player';
+
+class FakeOscillator {
+  type = 'sine';
+  frequency = { value: 0 };
+  connect() {}
+  start() {}
+  stop() {}
+}
+
+class FakeGain {
+  gain = {
+    setValueAtTime() {},
+    exponentialRampToValueAtTime() {},
+  };
+  connect() {}
+}
+
+class FakeAudioContext {
+  state = 'running';
+  currentTime = 0;
+  destination = {};
+  createOscillator() {
+    return new FakeOscillator();
+  }
+  createGain() {
+    return new FakeGain();
+  }
+  close() {}
+  resume() {}
+}
+
+beforeEach(() => {
+  // @ts-expect-error test stub
+  window.AudioContext = FakeAudioContext as unknown as typeof AudioContext;
+  // @ts-expect-error test stub
+  window.webkitAudioContext =
+    FakeAudioContext as unknown as typeof AudioContext;
+  player.stopPlayback();
+});
+
+describe('playChart metronome', () => {
+  it('skips clicks when disabled', () => {
+    const chart: Chart = {
+      schemaVersion: 1,
+      title: '',
+      sections: [
+        {
+          name: 'A',
+          measures: [
+            {
+              beats: [
+                { chord: '' },
+                { chord: '' },
+                { chord: '' },
+                { chord: '' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const spy = vi.spyOn(player.internal, 'scheduleClick');
+    player.playChart(chart, 120, false);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockClear();
+    player.playChart(chart, 120, true);
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -67,24 +67,26 @@ function scheduleChord(freqs: number[], start: number, duration: number) {
   });
 }
 
-function scheduleClick(start: number, accent: boolean) {
-  const ctx = getCtx();
-  const osc = ctx.createOscillator();
-  osc.type = 'square';
-  osc.frequency.value = accent ? 1000 : 800;
-  const gain = ctx.createGain();
-  osc.connect(gain);
-  gain.connect(ctx.destination);
-  const t = ctx.currentTime + start;
-  const end = t + 0.05;
-  gain.gain.setValueAtTime(0.0001, t);
-  gain.gain.exponentialRampToValueAtTime(accent ? 0.7 : 0.5, t + 0.001);
-  gain.gain.exponentialRampToValueAtTime(0.0001, end);
-  osc.start(t);
-  osc.stop(end);
-}
+export const internal = {
+  scheduleClick(start: number, accent: boolean) {
+    const ctx = getCtx();
+    const osc = ctx.createOscillator();
+    osc.type = 'square';
+    osc.frequency.value = accent ? 1000 : 800;
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    const t = ctx.currentTime + start;
+    const end = t + 0.05;
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.exponentialRampToValueAtTime(accent ? 0.7 : 0.5, t + 0.001);
+    gain.gain.exponentialRampToValueAtTime(0.0001, end);
+    osc.start(t);
+    osc.stop(end);
+  },
+};
 
-export function playChart(chart: Chart, tempo = 120) {
+export function playChart(chart: Chart, tempo = 120, metronome = true) {
   const ctx = getCtx();
   if (ctx.state === 'suspended') void ctx.resume();
   const beatDur = 60 / tempo;
@@ -92,7 +94,7 @@ export function playChart(chart: Chart, tempo = 120) {
   chart.sections.forEach((section) => {
     section.measures.forEach((m) => {
       m.beats.forEach((b, i) => {
-        scheduleClick(time, i === 0);
+        if (metronome) internal.scheduleClick(time, i === 0);
         if (b.chord) {
           const freqs = parseChord(b.chord);
           if (freqs.length) scheduleChord(freqs, time, beatDur);

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -35,6 +35,15 @@ describe('ChartStore', () => {
     expect(s2.showSecondary).toBe(false);
   });
 
+  it('toggles and persists metronome', () => {
+    const s = new ChartStore();
+    expect(s.metronome).toBe(true);
+    s.toggleMetronome();
+    expect(s.metronome).toBe(false);
+    const s2 = new ChartStore();
+    expect(s2.metronome).toBe(false);
+  });
+
   it('selects measures and applies markers', () => {
     const s = new ChartStore();
     s.setChart({

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -11,6 +11,7 @@ const SHOW_SECONDARY_KEY = 'jaireal.showSecondary';
 const VIEW_KEY = 'jaireal.view';
 const MANUAL_TRANSPOSE_KEY = 'jaireal.manualTranspose';
 const TEMPO_KEY = 'jaireal.tempo';
+const METRONOME_KEY = 'jaireal.metronome';
 
 type Instrument = 'C' | 'Bb' | 'Eb' | 'F';
 const instrumentSemitones: Record<Instrument, number> = {
@@ -42,6 +43,7 @@ export class ChartStore {
   preferSharps: boolean;
   manualTranspose = 0;
   tempo: number;
+  metronome: boolean;
   selectedSection: number | null = null;
   selectedMeasure: number | null = null;
   private listeners: Set<Listener> = new Set();
@@ -55,6 +57,7 @@ export class ChartStore {
     this.preferSharps = view.preferSharps;
     this.manualTranspose = this.loadManualTranspose();
     this.tempo = this.loadTempo();
+    this.metronome = this.loadMetronome();
   }
 
   private loadChart(): Chart {
@@ -152,6 +155,22 @@ export class ChartStore {
     );
   }
 
+  private loadMetronome(): boolean {
+    try {
+      const raw = localStorage.getItem(METRONOME_KEY);
+      if (raw !== null) {
+        return JSON.parse(raw) as boolean;
+      }
+    } catch {
+      // ignore
+    }
+    return true;
+  }
+
+  private persistMetronome() {
+    localStorage.setItem(METRONOME_KEY, JSON.stringify(this.metronome));
+  }
+
   subscribe(listener: Listener) {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
@@ -187,6 +206,12 @@ export class ChartStore {
   toggleSecondary() {
     this.showSecondary = !this.showSecondary;
     this.persistShowSecondary();
+    this.listeners.forEach((l) => l());
+  }
+
+  toggleMetronome() {
+    this.metronome = !this.metronome;
+    this.persistMetronome();
     this.listeners.forEach((l) => l());
   }
 

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -121,10 +121,21 @@ export function Controls(): HTMLElement {
   };
   tempoLabel.appendChild(tempoInput);
 
+  const metronomeBtn = document.createElement('button');
+  const updateMetronomeText = () => {
+    metronomeBtn.textContent = store.metronome
+      ? 'Desactivar metrónomo'
+      : 'Activar metrónomo';
+  };
+  updateMetronomeText();
+  metronomeBtn.onclick = () => {
+    store.toggleMetronome();
+  };
+
   const playBtn = document.createElement('button');
   playBtn.textContent = 'Reproducir';
   playBtn.onclick = () => {
-    playChart(store.chart, store.tempo);
+    playChart(store.chart, store.tempo, store.metronome);
   };
 
   const stopBtn = document.createElement('button');
@@ -234,6 +245,7 @@ export function Controls(): HTMLElement {
     updateViewControls();
     updateTransposeInfo();
     tempoInput.value = String(store.tempo);
+    updateMetronomeText();
   });
   updateMarkerSelect();
 
@@ -249,6 +261,7 @@ export function Controls(): HTMLElement {
     tempoLabel,
     playBtn,
     stopBtn,
+    metronomeBtn,
     instrumentLabel,
     instrumentSelect,
     accidentalLabel,


### PR DESCRIPTION
## Summary
- allow enabling or disabling metronome during playback
- remember metronome preference between sessions
- add tests for metronome toggle and audio scheduling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc07a86588333ab48cd312a745c83