### PR TITLE
feat: add metronome volume control

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -159,4 +159,6 @@ Criterios de aceptación (15B)
     20E) Persistencia de preferencia de metrónomo
     [x] Recordar si el metrónomo está activado entre sesiones.
     20F) Control de volumen del metrónomo
-    [ ] Ajustar el volumen del clic del metrónomo.
+    [x] Ajustar el volumen del clic del metrónomo.
+    20G) Atajo de teclado para volumen del metrónomo
+    [ ] Permitir ajustar el volumen con el teclado.

--- a/src/audio/player.test.ts
+++ b/src/audio/player.test.ts
@@ -69,4 +69,30 @@ describe('playChart metronome', () => {
     player.playChart(chart, 120, true);
     expect(spy).toHaveBeenCalled();
   });
+
+  it('passes metronome volume to scheduleClick', () => {
+    const chart: Chart = {
+      schemaVersion: 1,
+      title: '',
+      sections: [
+        {
+          name: 'A',
+          measures: [
+            {
+              beats: [
+                { chord: '' },
+                { chord: '' },
+                { chord: '' },
+                { chord: '' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const spy = vi.spyOn(player.internal, 'scheduleClick');
+    player.playChart(chart, 120, true, 0.3);
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][2]).toBe(0.3);
+  });
 });

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -68,7 +68,7 @@ function scheduleChord(freqs: number[], start: number, duration: number) {
 }
 
 export const internal = {
-  scheduleClick(start: number, accent: boolean) {
+  scheduleClick(start: number, accent: boolean, volume = 1) {
     const ctx = getCtx();
     const osc = ctx.createOscillator();
     osc.type = 'square';
@@ -79,14 +79,22 @@ export const internal = {
     const t = ctx.currentTime + start;
     const end = t + 0.05;
     gain.gain.setValueAtTime(0.0001, t);
-    gain.gain.exponentialRampToValueAtTime(accent ? 0.7 : 0.5, t + 0.001);
+    gain.gain.exponentialRampToValueAtTime(
+      (accent ? 0.7 : 0.5) * volume,
+      t + 0.001,
+    );
     gain.gain.exponentialRampToValueAtTime(0.0001, end);
     osc.start(t);
     osc.stop(end);
   },
 };
 
-export function playChart(chart: Chart, tempo = 120, metronome = true) {
+export function playChart(
+  chart: Chart,
+  tempo = 120,
+  metronome = true,
+  metronomeVolume = 1,
+) {
   const ctx = getCtx();
   if (ctx.state === 'suspended') void ctx.resume();
   const beatDur = 60 / tempo;
@@ -94,7 +102,7 @@ export function playChart(chart: Chart, tempo = 120, metronome = true) {
   chart.sections.forEach((section) => {
     section.measures.forEach((m) => {
       m.beats.forEach((b, i) => {
-        if (metronome) internal.scheduleClick(time, i === 0);
+        if (metronome) internal.scheduleClick(time, i === 0, metronomeVolume);
         if (b.chord) {
           const freqs = parseChord(b.chord);
           if (freqs.length) scheduleChord(freqs, time, beatDur);

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -44,6 +44,15 @@ describe('ChartStore', () => {
     expect(s2.metronome).toBe(false);
   });
 
+  it('sets and persists metronome volume', () => {
+    const s = new ChartStore();
+    expect(s.metronomeVolume).toBe(1);
+    s.setMetronomeVolume(0.25);
+    expect(s.metronomeVolume).toBe(0.25);
+    const s2 = new ChartStore();
+    expect(s2.metronomeVolume).toBe(0.25);
+  });
+
   it('selects measures and applies markers', () => {
     const s = new ChartStore();
     s.setChart({

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -12,6 +12,7 @@ const VIEW_KEY = 'jaireal.view';
 const MANUAL_TRANSPOSE_KEY = 'jaireal.manualTranspose';
 const TEMPO_KEY = 'jaireal.tempo';
 const METRONOME_KEY = 'jaireal.metronome';
+const METRONOME_VOLUME_KEY = 'jaireal.metronomeVolume';
 
 type Instrument = 'C' | 'Bb' | 'Eb' | 'F';
 const instrumentSemitones: Record<Instrument, number> = {
@@ -44,6 +45,7 @@ export class ChartStore {
   manualTranspose = 0;
   tempo: number;
   metronome: boolean;
+  metronomeVolume: number;
   selectedSection: number | null = null;
   selectedMeasure: number | null = null;
   private listeners: Set<Listener> = new Set();
@@ -58,6 +60,7 @@ export class ChartStore {
     this.manualTranspose = this.loadManualTranspose();
     this.tempo = this.loadTempo();
     this.metronome = this.loadMetronome();
+    this.metronomeVolume = this.loadMetronomeVolume();
   }
 
   private loadChart(): Chart {
@@ -171,6 +174,25 @@ export class ChartStore {
     localStorage.setItem(METRONOME_KEY, JSON.stringify(this.metronome));
   }
 
+  private loadMetronomeVolume(): number {
+    try {
+      const raw = localStorage.getItem(METRONOME_VOLUME_KEY);
+      if (raw !== null) {
+        return JSON.parse(raw) as number;
+      }
+    } catch {
+      // ignore
+    }
+    return 1;
+  }
+
+  private persistMetronomeVolume() {
+    localStorage.setItem(
+      METRONOME_VOLUME_KEY,
+      JSON.stringify(this.metronomeVolume),
+    );
+  }
+
   subscribe(listener: Listener) {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
@@ -212,6 +234,12 @@ export class ChartStore {
   toggleMetronome() {
     this.metronome = !this.metronome;
     this.persistMetronome();
+    this.listeners.forEach((l) => l());
+  }
+
+  setMetronomeVolume(vol: number) {
+    this.metronomeVolume = vol;
+    this.persistMetronomeVolume();
     this.listeners.forEach((l) => l());
   }
 

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -132,10 +132,26 @@ export function Controls(): HTMLElement {
     store.toggleMetronome();
   };
 
+  const metronomeVolLabel = document.createElement('label');
+  metronomeVolLabel.textContent = 'Volumen metrónomo: ';
+  const metronomeVolInput = document.createElement('input');
+  metronomeVolInput.type = 'range';
+  metronomeVolInput.min = '0';
+  metronomeVolInput.max = '1';
+  metronomeVolInput.step = '0.01';
+  metronomeVolInput.value = String(store.metronomeVolume);
+  metronomeVolInput.oninput = () => {
+    const val = Number(metronomeVolInput.value);
+    if (!Number.isNaN(val)) {
+      store.setMetronomeVolume(val);
+    }
+  };
+  metronomeVolLabel.appendChild(metronomeVolInput);
+
   const playBtn = document.createElement('button');
   playBtn.textContent = 'Reproducir';
   playBtn.onclick = () => {
-    playChart(store.chart, store.tempo, store.metronome);
+    playChart(store.chart, store.tempo, store.metronome, store.metronomeVolume);
   };
 
   const stopBtn = document.createElement('button');
@@ -246,6 +262,7 @@ export function Controls(): HTMLElement {
     updateTransposeInfo();
     tempoInput.value = String(store.tempo);
     updateMetronomeText();
+    metronomeVolInput.value = String(store.metronomeVolume);
   });
   updateMarkerSelect();
 
@@ -259,6 +276,7 @@ export function Controls(): HTMLElement {
     transposeInfo,
     resetTransposeBtn,
     tempoLabel,
+    metronomeVolLabel,
     playBtn,
     stopBtn,
     metronomeBtn,


### PR DESCRIPTION
## Summary
- add adjustable metronome volume with persistence
- expose volume slider in controls and pass through audio player
- test metronome volume and record new task in checklist

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc36427dc8333bdd568727ae3557e