### PR TITLE
feat: display metronome volume shortcuts

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -163,4 +163,6 @@ Criterios de aceptación (15B)
     20G) Atajo de teclado para volumen del metrónomo
     [x] Permitir ajustar el volumen con el teclado.
     20H) Mostrar atajo de volumen en la interfaz
-    [ ] Indicar en la UI los atajos de teclado para el volumen del metrónomo.
+    [x] Indicar en la UI los atajos de teclado para el volumen del metrónomo.
+    20I) Atajos de teclado para tempo
+    [ ] Permitir subir o bajar el tempo mediante combinaciones de teclas.

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -133,7 +133,9 @@ export function Controls(): HTMLElement {
   };
 
   const metronomeVolLabel = document.createElement('label');
-  metronomeVolLabel.textContent = 'Volumen metrónomo: ';
+  const metronomeVolShortcut = 'Ctrl+Shift+↑/↓';
+  metronomeVolLabel.textContent = `Volumen metrónomo (${metronomeVolShortcut}): `;
+  metronomeVolLabel.title = metronomeVolShortcut;
   const metronomeVolInput = document.createElement('input');
   metronomeVolInput.type = 'range';
   metronomeVolInput.min = '0';

--- a/tests/metronome-volume-shortcut.spec.ts
+++ b/tests/metronome-volume-shortcut.spec.ts
@@ -11,7 +11,11 @@ test.beforeEach(async ({ context }) => {
 test('adjust metronome volume with keyboard shortcuts', async ({ page }) => {
   await page.goto('/');
   await page.click('body');
-  const volInput = page.locator('label:has-text("Volumen metrónomo") input');
+  const volLabel = page.locator(
+    'label:has-text("Volumen metrónomo (Ctrl+Shift+↑/↓)")',
+  );
+  await expect(volLabel).toBeVisible();
+  const volInput = volLabel.locator('input');
   await expect(volInput).toHaveValue('0.5');
   await page.keyboard.press('Control+Shift+ArrowUp');
   await expect(volInput).toHaveValue('0.6');


### PR DESCRIPTION
## Summary
- show metronome volume keyboard shortcuts in controls
- test metronome volume shortcut label
- update tasks checklist and add tempo shortcut task

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68adc5fd337c83339eacd67a43a35ebe