### PR TITLE
feat: add tempo and playback keyboard shortcuts

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -165,4 +165,8 @@ Criterios de aceptación (15B)
     20H) Mostrar atajo de volumen en la interfaz
     [x] Indicar en la UI los atajos de teclado para el volumen del metrónomo.
     20I) Atajos de teclado para tempo
-    [ ] Permitir subir o bajar el tempo mediante combinaciones de teclas.
+    [x] Permitir subir o bajar el tempo mediante combinaciones de teclas.
+    20J) Atajo de teclado para reproducir/detener
+    [x] Espacio para iniciar o detener la reproducción.
+    20K) Control de tempo con la rueda del ratón
+    [ ] Ajustar el tempo girando la rueda sobre el control correspondiente.

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -119,3 +119,7 @@ export function stopPlayback() {
     audioCtx = null;
   }
 }
+
+export function isPlaying() {
+  return audioCtx !== null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { Rail } from './ui/components/Rail';
 import { Grid } from './ui/components/Grid';
 import { Controls } from './ui/components/Controls';
 import { store } from './state/store';
+import { playChart, stopPlayback, isPlaying } from './audio/player';
 
 const app = document.querySelector<HTMLDivElement>('#app')!;
 app.append(Header(), Rail(), Grid(), Controls());
@@ -49,6 +50,32 @@ window.addEventListener('keydown', (ev) => {
   }
   if (ev.ctrlKey && ev.key === 'ArrowDown') {
     store.transpose(-1);
+    ev.preventDefault();
+    return;
+  }
+  if (ev.ctrlKey && ev.key === 'ArrowRight') {
+    const bpm = Math.min(240, store.tempo + 5);
+    store.setTempo(bpm);
+    ev.preventDefault();
+    return;
+  }
+  if (ev.ctrlKey && ev.key === 'ArrowLeft') {
+    const bpm = Math.max(40, store.tempo - 5);
+    store.setTempo(bpm);
+    ev.preventDefault();
+    return;
+  }
+  if (ev.code === 'Space') {
+    if (isPlaying()) {
+      stopPlayback();
+    } else {
+      playChart(
+        store.chart,
+        store.tempo,
+        store.metronome,
+        store.metronomeVolume,
+      );
+    }
     ev.preventDefault();
   }
 });

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -107,7 +107,9 @@ export function Controls(): HTMLElement {
   };
 
   const tempoLabel = document.createElement('label');
-  tempoLabel.textContent = 'Tempo: ';
+  const tempoShortcut = 'Ctrl+←/→';
+  tempoLabel.textContent = `Tempo (${tempoShortcut}): `;
+  tempoLabel.title = tempoShortcut;
   const tempoInput = document.createElement('input');
   tempoInput.type = 'number';
   tempoInput.min = '40';
@@ -151,13 +153,16 @@ export function Controls(): HTMLElement {
   metronomeVolLabel.appendChild(metronomeVolInput);
 
   const playBtn = document.createElement('button');
-  playBtn.textContent = 'Reproducir';
+  const playShortcut = 'Espacio';
+  playBtn.textContent = `Reproducir (${playShortcut})`;
+  playBtn.title = playShortcut;
   playBtn.onclick = () => {
     playChart(store.chart, store.tempo, store.metronome, store.metronomeVolume);
   };
 
   const stopBtn = document.createElement('button');
-  stopBtn.textContent = 'Detener';
+  stopBtn.textContent = `Detener (${playShortcut})`;
+  stopBtn.title = playShortcut;
   stopBtn.onclick = () => {
     stopPlayback();
   };

--- a/tests/tempo-shortcut.spec.ts
+++ b/tests/tempo-shortcut.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('jaireal.showSecondary', 'true');
+    window.localStorage.setItem('jaireal.tempo', '120');
+  });
+});
+
+test('adjust tempo with keyboard shortcuts', async ({ page }) => {
+  await page.goto('/');
+  await page.click('body');
+  const tempoLabel = page.locator('label:has-text("Tempo (Ctrl+←/→)")');
+  await expect(tempoLabel).toBeVisible();
+  const tempoInput = tempoLabel.locator('input');
+  await expect(tempoInput).toHaveValue('120');
+  await page.keyboard.press('Control+ArrowRight');
+  await expect(tempoInput).toHaveValue('125');
+  await page.keyboard.press('Control+ArrowLeft');
+  await expect(tempoInput).toHaveValue('120');
+});


### PR DESCRIPTION
## Summary
- add keyboard shortcuts to adjust tempo and toggle playback
- expose playback state and show tempo shortcut in UI
- cover tempo shortcut with end-to-end tests and update tasks checklist

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68adc798aae8833398ceeafa2be59860