### PR TITLE
feat: add voltas and chart templates

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -59,7 +59,7 @@ Convenciones: [ ] pendiente · [x] hecho
    [x] Hecho.
 
 8. Voltas
-   [ ] 1ª/2ª con rango; overlay y persistencia.
+   [x] 1ª/2ª con rango; overlay y persistencia.
 
 9. Transposición
    9A) Semitonos sobre toda la partitura
@@ -85,7 +85,7 @@ Convenciones: [ ] pendiente · [x] hecho
 [x] Hecho.
 
 10. Plantillas
-    [ ] AABA/Blues/Rhythm Changes/Intro-Tag-Out.
+    [x] AABA/Blues/Rhythm Changes/Intro-Tag-Out.
 
 11. Exportación
     [ ] PDF; (PNG/SVG en v1).
@@ -174,3 +174,7 @@ Criterios de aceptación (15B)
     [x] Indicar en la UI que se puede usar la rueda del ratón para el tempo.
     20M) Pruebas automáticas para la rueda de tempo
     [x] Hecho.
+    20N) Reproducción en bucle de sección
+    [ ] Permitir reproducir una sección de forma repetida.
+    20O) Control de volumen maestro
+    [ ] Ajustar el volumen general de la reproducción.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Editor de cifrados orientado a trabajo offline.
 Incluye reproducción básica de acordes con la Web Audio API.
+Soporta plantillas AABA, Blues, Rhythm Changes e Intro-Tag-Out, además de
+voltas de 1ª y 2ª con rango.
 
 ## Requisitos
 

--- a/src/core/templates.test.ts
+++ b/src/core/templates.test.ts
@@ -1,0 +1,16 @@
+import { getTemplate } from './templates';
+import { describe, it, expect } from 'vitest';
+
+describe('templates', () => {
+  it('creates AABA chart', () => {
+    const chart = getTemplate('AABA');
+    expect(chart.sections.length).toBe(4);
+    expect(chart.sections[0].measures.length).toBe(8);
+  });
+
+  it('creates Blues chart', () => {
+    const chart = getTemplate('Blues');
+    expect(chart.sections[0].measures.length).toBe(12);
+    expect(chart.sections[0].measures[0].beats[0].chord).toBe('I7');
+  });
+});

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -1,0 +1,79 @@
+import type { Chart, Measure } from './model';
+import { schemaVersion } from './model';
+
+export type TemplateName =
+  | 'AABA'
+  | 'Blues'
+  | 'Rhythm Changes'
+  | 'Intro-Tag-Out';
+
+const emptyMeasure = (): Measure => ({
+  beats: [{ chord: '' }, { chord: '' }, { chord: '' }, { chord: '' }],
+});
+
+const measures = (n: number): Measure[] =>
+  Array.from({ length: n }, () => emptyMeasure());
+
+export const templates: Record<TemplateName, Chart> = {
+  AABA: {
+    schemaVersion,
+    title: '',
+    sections: [
+      { name: 'A', measures: measures(8) },
+      { name: 'A', measures: measures(8) },
+      { name: 'B', measures: measures(8) },
+      { name: 'A', measures: measures(8) },
+    ],
+  },
+  Blues: {
+    schemaVersion,
+    title: '',
+    sections: [
+      {
+        name: 'Blues',
+        measures: measures(12).map((m, i) => {
+          const chords = [
+            'I7',
+            'IV7',
+            'I7',
+            'I7',
+            'IV7',
+            'IV7',
+            'I7',
+            'I7',
+            'V7',
+            'IV7',
+            'I7',
+            'V7',
+          ];
+          m.beats[0].chord = chords[i];
+          return m;
+        }),
+      },
+    ],
+  },
+  'Rhythm Changes': {
+    schemaVersion,
+    title: '',
+    sections: [
+      { name: 'A', measures: measures(8) },
+      { name: 'A', measures: measures(8) },
+      { name: 'B', measures: measures(8) },
+      { name: 'A', measures: measures(8) },
+    ],
+  },
+  'Intro-Tag-Out': {
+    schemaVersion,
+    title: '',
+    sections: [
+      { name: 'Intro', measures: measures(4) },
+      { name: 'A', measures: measures(8) },
+      { name: 'Tag', measures: measures(4) },
+      { name: 'Out', measures: measures(4) },
+    ],
+  },
+};
+
+export function getTemplate(name: TemplateName): Chart {
+  return JSON.parse(JSON.stringify(templates[name])) as Chart;
+}

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -250,4 +250,28 @@ describe('ChartStore', () => {
     const s2 = new ChartStore();
     expect(s2.manualTranspose).toBe(2);
   });
+
+  it('sets and clears voltas', () => {
+    const s = new ChartStore();
+    s.setChart({
+      schemaVersion: 1,
+      title: 't',
+      sections: [
+        {
+          name: 'A',
+          measures: Array.from({ length: 4 }, () => ({
+            beats: [{ chord: '' }, { chord: '' }, { chord: '' }, { chord: '' }],
+          })),
+        },
+      ],
+    });
+    s.setVolta(0, 1, 0, 1);
+    expect(s.chart.sections[0].measures[0].volta).toEqual({
+      number: 1,
+      from: 0,
+      to: 1,
+    });
+    s.clearVolta(0, 1);
+    expect(s.chart.sections[0].measures[0].volta).toBeUndefined();
+  });
 });

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -381,6 +381,30 @@ export class ChartStore {
     this.setChart(this.chart);
     return true;
   }
+
+  setVolta(sectionIndex: number, number: 1 | 2, from: number, to: number) {
+    const section = this.chart.sections[sectionIndex];
+    if (!section) return;
+    section.measures.forEach((m) => {
+      if (m.volta?.number === number) delete m.volta;
+    });
+    if (from < 0 || to >= section.measures.length || from > to) return;
+    section.measures[from].volta = { number, from, to };
+    this.setChart(this.chart);
+  }
+
+  clearVolta(sectionIndex: number, number: 1 | 2) {
+    const section = this.chart.sections[sectionIndex];
+    if (!section) return;
+    let changed = false;
+    section.measures.forEach((m) => {
+      if (m.volta?.number === number) {
+        delete m.volta;
+        changed = true;
+      }
+    });
+    if (changed) this.setChart(this.chart);
+  }
 }
 
 export const store = new ChartStore();

--- a/src/style.css
+++ b/src/style.css
@@ -22,6 +22,8 @@ header {
 
 .section {
   margin-bottom: 1rem;
+  display: flex;
+  position: relative;
 }
 
 .section-title {
@@ -54,6 +56,22 @@ header {
   width: 100%;
   text-align: center;
   font-size: 0.75rem;
+}
+
+.volta-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 0;
+}
+
+.volta {
+  position: absolute;
+  top: -1.5rem;
+  border: 1px solid #000;
+  border-bottom: none;
+  font-size: 0.75rem;
+  padding: 0 0.25rem;
 }
 
 .slot {

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -1,6 +1,7 @@
 import { store } from '../../state/store';
 import type { Marker } from '../../core/model';
 import { playChart, stopPlayback } from '../../audio/player';
+import { getTemplate, type TemplateName } from '../../core/templates';
 
 export function Controls(): HTMLElement {
   const el = document.createElement('div');
@@ -60,6 +61,29 @@ export function Controls(): HTMLElement {
       store.fromJSON(text);
     }
   };
+
+  const templateLabel = document.createElement('label');
+  templateLabel.textContent = 'Plantilla: ';
+  const templateSelect = document.createElement('select');
+  const templateOptions: TemplateName[] = [
+    'AABA',
+    'Blues',
+    'Rhythm Changes',
+    'Intro-Tag-Out',
+  ];
+  templateOptions.forEach((t) => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    templateSelect.appendChild(opt);
+  });
+  const templateBtn = document.createElement('button');
+  templateBtn.textContent = 'Nueva desde plantilla';
+  templateBtn.onclick = () => {
+    const name = templateSelect.value as TemplateName;
+    store.setChart(getTemplate(name));
+  };
+  templateLabel.appendChild(templateSelect);
 
   const toggleSecondaryBtn = document.createElement('button');
   const shortcut = 'Ctrl+Shift+L';
@@ -222,6 +246,43 @@ export function Controls(): HTMLElement {
     );
   };
 
+  const voltaLabel = document.createElement('label');
+  voltaLabel.textContent = 'Volta: ';
+  const voltaSelect = document.createElement('select');
+  ['', '1', '2'].forEach((v) => {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = v ? `${v}ª` : '(sin)';
+    voltaSelect.appendChild(opt);
+  });
+  const voltaFrom = document.createElement('input');
+  voltaFrom.type = 'number';
+  voltaFrom.min = '1';
+  voltaFrom.placeholder = 'desde';
+  const voltaTo = document.createElement('input');
+  voltaTo.type = 'number';
+  voltaTo.min = '1';
+  voltaTo.placeholder = 'hasta';
+  const voltaBtn = document.createElement('button');
+  voltaBtn.textContent = 'Aplicar';
+  voltaBtn.onclick = () => {
+    if (store.selectedSection === null) return;
+    const num = Number(voltaSelect.value);
+    const from = Number(voltaFrom.value) - 1;
+    const to = Number(voltaTo.value) - 1;
+    if (num && !Number.isNaN(from) && !Number.isNaN(to)) {
+      store.setVolta(store.selectedSection, num as 1 | 2, from, to);
+    }
+  };
+  const clearVoltaBtn = document.createElement('button');
+  clearVoltaBtn.textContent = 'Borrar voltas';
+  clearVoltaBtn.onclick = () => {
+    if (store.selectedSection === null) return;
+    store.clearVolta(store.selectedSection, 1);
+    store.clearVolta(store.selectedSection, 2);
+  };
+  voltaLabel.append(voltaSelect, voltaFrom, voltaTo, voltaBtn);
+
   const markerLabel = document.createElement('label');
   markerLabel.textContent = 'Marcador: ';
   const markerSelect = document.createElement('select');
@@ -285,6 +346,8 @@ export function Controls(): HTMLElement {
   el.append(
     saveBtn,
     loadInput,
+    templateLabel,
+    templateBtn,
     toggleSecondaryBtn,
     transposeUpBtn,
     transposeDownBtn,
@@ -299,6 +362,8 @@ export function Controls(): HTMLElement {
     instrumentSelect,
     accidentalLabel,
     accidentalSelect,
+    voltaLabel,
+    clearVoltaBtn,
     markerLabel,
     messageEl,
   );

--- a/src/ui/components/Grid.ts
+++ b/src/ui/components/Grid.ts
@@ -20,6 +20,8 @@ export function Grid(): HTMLElement {
       title.textContent = section.name;
       sectionEl.appendChild(title);
 
+      const measureEls: HTMLElement[] = [];
+
       section.measures.forEach((measure, mIdx) => {
         const measureEl = document.createElement('div');
         measureEl.className = 'measure';
@@ -178,10 +180,34 @@ export function Grid(): HTMLElement {
           measureEl.appendChild(slot);
         }
 
+        measureEls.push(measureEl);
         sectionEl.appendChild(measureEl);
       });
 
+      const voltaContainer = document.createElement('div');
+      voltaContainer.className = 'volta-container';
+      sectionEl.appendChild(voltaContainer);
+
       el.appendChild(sectionEl);
+
+      requestAnimationFrame(() => {
+        voltaContainer.innerHTML = '';
+        section.measures.forEach((measure, mIdx) => {
+          if (measure.volta && measure.volta.from === mIdx) {
+            const startEl = measureEls[mIdx];
+            const endEl = measureEls[measure.volta.to];
+            if (!startEl || !endEl) return;
+            const voltaEl = document.createElement('div');
+            voltaEl.className = 'volta';
+            voltaEl.textContent = `${measure.volta.number}ª`;
+            const left = startEl.offsetLeft;
+            const width = endEl.offsetLeft + endEl.offsetWidth - left;
+            voltaEl.style.left = `${left}px`;
+            voltaEl.style.width = `${width}px`;
+            voltaContainer.appendChild(voltaEl);
+          }
+        });
+      });
     });
   };
 


### PR DESCRIPTION
## Summary
- add 1st and 2nd ending voltas with overlay and persistence
- provide AABA, Blues, Rhythm Changes and Intro-Tag-Out templates
- document new music features

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adcb05eb208333a6ef800179176761