### PR TITLE
feat: add master volume keyboard shortcuts

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -179,6 +179,8 @@ Criterios de aceptación (15B)
     20O) Control de volumen maestro
     [x] Ajustar el volumen general de la reproducción.
     20P) Atajo de teclado para volumen maestro
-    [ ] Permitir ajustar el volumen maestro con combinaciones de teclas.
+    [x] Permitir ajustar el volumen maestro con combinaciones de teclas.
     20Q) Mostrar atajo de volumen maestro en la interfaz
-    [ ] Indicar en la UI los atajos de teclado para el volumen maestro.
+    [x] Indicar en la UI los atajos de teclado para el volumen maestro.
+    20R) Atajo para restablecer volumen maestro
+    [ ] Permitir volver el volumen maestro a 100% con un atajo de teclado.

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,18 @@ window.addEventListener('keydown', (ev) => {
     ev.preventDefault();
     return;
   }
+  if (ev.altKey && ev.shiftKey && ev.key === 'ArrowUp') {
+    const vol = Math.min(1, Math.round((store.masterVolume + 0.1) * 100) / 100);
+    store.setMasterVolume(vol);
+    ev.preventDefault();
+    return;
+  }
+  if (ev.altKey && ev.shiftKey && ev.key === 'ArrowDown') {
+    const vol = Math.max(0, Math.round((store.masterVolume - 0.1) * 100) / 100);
+    store.setMasterVolume(vol);
+    ev.preventDefault();
+    return;
+  }
   if (ev.ctrlKey && ev.shiftKey && ev.key === 'ArrowUp') {
     const vol = Math.min(
       1,

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -161,7 +161,9 @@ export function Controls(): HTMLElement {
   tempoLabel.appendChild(tempoInput);
 
   const masterVolLabel = document.createElement('label');
-  masterVolLabel.textContent = 'Volumen: ';
+  const masterVolShortcut = 'Alt+Shift+↑/↓';
+  masterVolLabel.textContent = `Volumen (${masterVolShortcut}): `;
+  masterVolLabel.title = masterVolShortcut;
   const masterVolInput = document.createElement('input');
   masterVolInput.type = 'range';
   masterVolInput.min = '0';

--- a/tests/master-volume-shortcut.spec.ts
+++ b/tests/master-volume-shortcut.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('jaireal.showSecondary', 'true');
+    window.localStorage.setItem('jaireal.masterVolume', '0.5');
+  });
+});
+
+test('adjust master volume with keyboard shortcuts', async ({ page }) => {
+  await page.goto('/');
+  await page.click('body');
+  const volLabel = page.locator('label:has-text("Volumen (Alt+Shift+↑/↓)")');
+  await expect(volLabel).toBeVisible();
+  const volInput = volLabel.locator('input');
+  await expect(volInput).toHaveValue('0.5');
+  await page.keyboard.press('Alt+Shift+ArrowUp');
+  await expect(volInput).toHaveValue('0.6');
+  await page.keyboard.press('Alt+Shift+ArrowDown');
+  await expect(volInput).toHaveValue('0.5');
+});


### PR DESCRIPTION
## Summary
- add Alt+Shift+Arrow shortcuts for master volume
- display master volume shortcuts in controls UI
- test master volume keyboard shortcuts

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade15537788333a1502cfa475c3192