### PR TITLE
feat: add basic CSV importer

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -96,7 +96,12 @@ Convenciones: [ ] pendiente · [x] hecho
     [ ] IndexedDB; etiquetas + búsqueda básica.
 
 13. Importadores
-    [ ] ChordPro/iReal/CSV; tests.
+    13A) CSV básico
+        [x] Importación CSV simple con tests.
+    13B) ChordPro
+        [ ] Pendiente.
+    13C) iReal
+        [ ] Pendiente.
 
 14. Preferencias/Vista
     [ ] Tema, fuentes/tamaños, ♯/♭.

--- a/src/importers/csv.test.ts
+++ b/src/importers/csv.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { parseCSV } from './csv';
+
+describe('CSV importer', () => {
+  it('parses title and measures from CSV', () => {
+    const csv = 'title,My Song\nC,F,G,C\nDm,G,C,F';
+    const chart = parseCSV(csv);
+    expect(chart.title).toBe('My Song');
+    expect(chart.sections).toHaveLength(1);
+    expect(chart.sections[0].measures).toHaveLength(2);
+    expect(chart.sections[0].measures[0].beats[1].chord).toBe('F');
+    expect(chart.sections[0].measures[1].beats[2].chord).toBe('C');
+  });
+});

--- a/src/importers/csv.ts
+++ b/src/importers/csv.ts
@@ -1,0 +1,37 @@
+import type { BeatSlot, Chart, Measure } from '../core/model';
+
+/**
+ * Parse a simple CSV representation of a chart. The CSV format is:
+ *   Optional header line: `title,My Song`
+ *   Each subsequent line represents a measure with up to four comma-separated chords.
+ *   Missing chords are filled with empty strings.
+ */
+export function parseCSV(input: string): Chart {
+  const lines = input
+    .trim()
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  let title = '';
+  const measures: Measure[] = [];
+
+  lines.forEach((line, idx) => {
+    const cells = line.split(',').map((c) => c.trim());
+    if (idx === 0 && cells[0].toLowerCase() === 'title') {
+      title = cells[1] ?? '';
+      return;
+    }
+    const beats: BeatSlot[] = [];
+    for (let i = 0; i < 4; i++) {
+      beats.push({ chord: cells[i] ?? '' });
+    }
+    measures.push({ beats });
+  });
+
+  return {
+    schemaVersion: 1,
+    title,
+    sections: [{ name: 'A', measures }],
+  };
+}


### PR DESCRIPTION
## Summary
- add simple CSV importer to convert comma-separated chords into a chart
- cover CSV importer with unit tests
- document CSV importer task completion in AGENTS_tareas

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade480a7408333b881f5b461e10941