### PR TITLE
feat: add chord volume control

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -189,7 +189,15 @@ Criterios de aceptación (15B)
     [x] Permitir ajustar el volumen maestro con combinaciones de teclas.
     20Q) Mostrar atajo de volumen maestro en la interfaz
     [x] Indicar en la UI los atajos de teclado para el volumen maestro.
-    20R) Atajo para restablecer volumen maestro
-    [x] Permitir volver el volumen maestro a 100% con un atajo de teclado.
-    20S) Pruebas automáticas para reset de volumen maestro
-    [x] Hecho.
+  20R) Atajo para restablecer volumen maestro
+  [x] Permitir volver el volumen maestro a 100% con un atajo de teclado.
+  20S) Pruebas automáticas para reset de volumen maestro
+  [x] Hecho.
+  20T) Control de volumen de acordes
+  [x] Ajustar el volumen de los acordes de reproducción.
+  20U) Atajo de teclado para volumen de acordes
+  [x] Permitir ajustar el volumen de los acordes con combinaciones de teclas.
+  20V) Mostrar atajo de volumen de acordes en la interfaz
+  [x] Indicar en la UI los atajos de teclado para el volumen de los acordes.
+  20W) Persistencia de volumen de acordes
+  [x] Recordar el volumen de los acordes entre sesiones.

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,18 @@ const app = document.querySelector<HTMLDivElement>('#app')!;
 app.append(Header(), Rail(), Grid(), Controls());
 
 window.addEventListener('keydown', (ev) => {
+  if (ev.ctrlKey && ev.altKey && ev.shiftKey && ev.key === 'ArrowUp') {
+    const vol = Math.min(1, Math.round((store.chordVolume + 0.1) * 100) / 100);
+    store.setChordVolume(vol);
+    ev.preventDefault();
+    return;
+  }
+  if (ev.ctrlKey && ev.altKey && ev.shiftKey && ev.key === 'ArrowDown') {
+    const vol = Math.max(0, Math.round((store.chordVolume - 0.1) * 100) / 100);
+    store.setChordVolume(vol);
+    ev.preventDefault();
+    return;
+  }
   if (ev.ctrlKey && ev.altKey && ev.key === 'ArrowUp') {
     store.transpose(12);
     ev.preventDefault();
@@ -91,6 +103,7 @@ window.addEventListener('keydown', (ev) => {
         store.tempo,
         store.metronome,
         store.metronomeVolume,
+        store.chordVolume,
       );
     }
     ev.preventDefault();

--- a/src/state/store.test.ts
+++ b/src/state/store.test.ts
@@ -62,6 +62,15 @@ describe('ChartStore', () => {
     expect(s2.masterVolume).toBe(0.5);
   });
 
+  it('sets and persists chord volume', () => {
+    const s = new ChartStore();
+    expect(s.chordVolume).toBe(1);
+    s.setChordVolume(0.5);
+    expect(s.chordVolume).toBe(0.5);
+    const s2 = new ChartStore();
+    expect(s2.chordVolume).toBe(0.5);
+  });
+
   it('selects measures and applies markers', () => {
     const s = new ChartStore();
     s.setChart({

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -14,6 +14,7 @@ const TEMPO_KEY = 'jaireal.tempo';
 const METRONOME_KEY = 'jaireal.metronome';
 const METRONOME_VOLUME_KEY = 'jaireal.metronomeVolume';
 const MASTER_VOLUME_KEY = 'jaireal.masterVolume';
+const CHORD_VOLUME_KEY = 'jaireal.chordVolume';
 
 type Instrument = 'C' | 'Bb' | 'Eb' | 'F';
 const instrumentSemitones: Record<Instrument, number> = {
@@ -48,6 +49,7 @@ export class ChartStore {
   metronome: boolean;
   metronomeVolume: number;
   masterVolume: number;
+  chordVolume: number;
   selectedSection: number | null = null;
   selectedMeasure: number | null = null;
   private listeners: Set<Listener> = new Set();
@@ -64,6 +66,7 @@ export class ChartStore {
     this.metronome = this.loadMetronome();
     this.metronomeVolume = this.loadMetronomeVolume();
     this.masterVolume = this.loadMasterVolume();
+    this.chordVolume = this.loadChordVolume();
   }
 
   private loadChart(): Chart {
@@ -205,6 +208,22 @@ export class ChartStore {
     localStorage.setItem(MASTER_VOLUME_KEY, JSON.stringify(this.masterVolume));
   }
 
+  private loadChordVolume(): number {
+    try {
+      const raw = localStorage.getItem(CHORD_VOLUME_KEY);
+      if (raw !== null) {
+        return JSON.parse(raw) as number;
+      }
+    } catch {
+      // ignore
+    }
+    return 1;
+  }
+
+  private persistChordVolume() {
+    localStorage.setItem(CHORD_VOLUME_KEY, JSON.stringify(this.chordVolume));
+  }
+
   private persistMetronomeVolume() {
     localStorage.setItem(
       METRONOME_VOLUME_KEY,
@@ -265,6 +284,12 @@ export class ChartStore {
   setMasterVolume(vol: number) {
     this.masterVolume = vol;
     this.persistMasterVolume();
+    this.listeners.forEach((l) => l());
+  }
+
+  setChordVolume(vol: number) {
+    this.chordVolume = vol;
+    this.persistChordVolume();
     this.listeners.forEach((l) => l());
   }
 

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -185,6 +185,24 @@ export function Controls(): HTMLElement {
   };
   masterVolLabel.appendChild(masterVolInput);
 
+  const chordVolLabel = document.createElement('label');
+  const chordVolShortcut = 'Ctrl+Alt+Shift+↑/↓';
+  chordVolLabel.textContent = `Volumen acordes (${chordVolShortcut}): `;
+  chordVolLabel.title = chordVolShortcut;
+  const chordVolInput = document.createElement('input');
+  chordVolInput.type = 'range';
+  chordVolInput.min = '0';
+  chordVolInput.max = '1';
+  chordVolInput.step = '0.01';
+  chordVolInput.value = String(store.chordVolume);
+  chordVolInput.oninput = () => {
+    const val = Number(chordVolInput.value);
+    if (!Number.isNaN(val)) {
+      store.setChordVolume(val);
+    }
+  };
+  chordVolLabel.appendChild(chordVolInput);
+
   const metronomeBtn = document.createElement('button');
   const updateMetronomeText = () => {
     metronomeBtn.textContent = store.metronome
@@ -220,7 +238,13 @@ export function Controls(): HTMLElement {
   playBtn.title = playShortcut;
   playBtn.onclick = () => {
     setMasterVolume(store.masterVolume);
-    playChart(store.chart, store.tempo, store.metronome, store.metronomeVolume);
+    playChart(
+      store.chart,
+      store.tempo,
+      store.metronome,
+      store.metronomeVolume,
+      store.chordVolume,
+    );
   };
 
   const stopBtn = document.createElement('button');
@@ -241,6 +265,7 @@ export function Controls(): HTMLElement {
         store.tempo,
         store.metronome,
         store.metronomeVolume,
+        store.chordVolume,
       );
     }
   };
@@ -386,6 +411,7 @@ export function Controls(): HTMLElement {
     updateMetronomeText();
     metronomeVolInput.value = String(store.metronomeVolume);
     masterVolInput.value = String(store.masterVolume);
+    chordVolInput.value = String(store.chordVolume);
   });
   updateMarkerSelect();
 
@@ -403,6 +429,7 @@ export function Controls(): HTMLElement {
     resetTransposeBtn,
     tempoLabel,
     masterVolLabel,
+    chordVolLabel,
     metronomeVolLabel,
     playBtn,
     stopBtn,

--- a/tests/chord-volume-shortcut.spec.ts
+++ b/tests/chord-volume-shortcut.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ context }) => {
+  await context.addInitScript(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem('jaireal.showSecondary', 'true');
+    window.localStorage.setItem('jaireal.chordVolume', '0.5');
+  });
+});
+
+test('adjust chord volume with keyboard shortcuts', async ({ page }) => {
+  await page.goto('/');
+  await page.click('body');
+  const volLabel = page.locator(
+    'label:has-text("Volumen acordes (Ctrl+Alt+Shift+↑/↓)")',
+  );
+  await expect(volLabel).toBeVisible();
+  const volInput = volLabel.locator('input');
+  await expect(volInput).toHaveValue('0.5');
+  await page.keyboard.press('Control+Alt+Shift+ArrowUp');
+  await expect(volInput).toHaveValue('0.6');
+  await page.keyboard.press('Control+Alt+Shift+ArrowDown');
+  await expect(volInput).toHaveValue('0.5');
+});


### PR DESCRIPTION
## Summary
- add adjustable chord volume with persistence
- support keyboard shortcuts for chord volume and show hint in UI
- cover chord volume shortcuts with e2e test

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ade5d517b08333914d0f4370f1b608