### PR TITLE
feat: add basic ChordPro and iReal importers with tests

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -99,8 +99,10 @@ Convenciones: [ ] pendiente · [x] hecho
     13A) CSV básico
         [x] Importación CSV simple con tests.
     13B) ChordPro
-        [ ] Pendiente.
+        [x] Importación ChordPro simple con tests.
     13C) iReal
+        [x] Importación iReal simple con tests.
+    13D) MusicXML
         [ ] Pendiente.
 
 14. Preferencias/Vista

--- a/src/importers/chordpro.test.ts
+++ b/src/importers/chordpro.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { parseChordPro } from './chordpro';
+
+describe('ChordPro importer', () => {
+  it('parses title and chords from ChordPro format', () => {
+    const input = `{title: My Song}\n[C][F][G][C]\n[Dm][G][C][F]\n`;
+    const chart = parseChordPro(input);
+    expect(chart.title).toBe('My Song');
+    expect(chart.sections).toHaveLength(1);
+    expect(chart.sections[0].measures).toHaveLength(2);
+    expect(chart.sections[0].measures[0].beats[1].chord).toBe('F');
+    expect(chart.sections[0].measures[1].beats[2].chord).toBe('C');
+  });
+});

--- a/src/importers/chordpro.ts
+++ b/src/importers/chordpro.ts
@@ -1,0 +1,40 @@
+import type { BeatSlot, Chart, Measure } from '../core/model';
+
+/**
+ * Parse a minimal subset of the ChordPro format. Supports:
+ *  - {title: My Song} directive for the chart title
+ *  - Chords in square brackets, e.g. [C] or [Dm7]
+ *  - Chords are collected sequentially and grouped into measures of 4 beats
+ */
+export function parseChordPro(input: string): Chart {
+  const lines = input.split(/\r?\n/);
+  let title = '';
+  const chords: string[] = [];
+  const chordRegex = /\[([^\]]+)\]/g;
+
+  for (const line of lines) {
+    const titleMatch = line.match(/\{title:\s*([^}]+)\}/i);
+    if (titleMatch) {
+      title = titleMatch[1].trim();
+    }
+    let m: RegExpExecArray | null;
+    while ((m = chordRegex.exec(line)) !== null) {
+      chords.push(m[1].trim());
+    }
+  }
+
+  const measures: Measure[] = [];
+  for (let i = 0; i < chords.length; i += 4) {
+    const beats: BeatSlot[] = [];
+    for (let j = 0; j < 4; j++) {
+      beats.push({ chord: chords[i + j] ?? '' });
+    }
+    measures.push({ beats });
+  }
+
+  return {
+    schemaVersion: 1,
+    title,
+    sections: [{ name: 'A', measures }],
+  };
+}

--- a/src/importers/ireal.test.ts
+++ b/src/importers/ireal.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { parseIReal } from './ireal';
+
+describe('iReal importer', () => {
+  it('parses title and measures from iReal text', () => {
+    const text = `My Song\nC F | G C\nDm G | C F`;
+    const chart = parseIReal(text);
+    expect(chart.title).toBe('My Song');
+    expect(chart.sections).toHaveLength(1);
+    expect(chart.sections[0].measures).toHaveLength(2);
+    expect(chart.sections[0].measures[0].beats[1].chord).toBe('F');
+    expect(chart.sections[0].measures[1].beats[2].chord).toBe('C');
+  });
+});

--- a/src/importers/ireal.ts
+++ b/src/importers/ireal.ts
@@ -1,0 +1,37 @@
+import type { BeatSlot, Chart, Measure } from '../core/model';
+
+/**
+ * Parse a simple text-based iReal format. Supports:
+ *  - First line as the chart title
+ *  - Remaining lines contain chords separated by spaces and optional '|' for measure breaks
+ *  - Chords are grouped into measures of 4 beats
+ */
+export function parseIReal(input: string): Chart {
+  const lines = input
+    .trim()
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  const title = lines.shift() ?? '';
+  const chordTokens = lines
+    .join(' ')
+    .split(/\s+|\|/)
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
+
+  const measures: Measure[] = [];
+  for (let i = 0; i < chordTokens.length; i += 4) {
+    const beats: BeatSlot[] = [];
+    for (let j = 0; j < 4; j++) {
+      beats.push({ chord: chordTokens[i + j] ?? '' });
+    }
+    measures.push({ beats });
+  }
+
+  return {
+    schemaVersion: 1,
+    title,
+    sections: [{ name: 'A', measures }],
+  };
+}


### PR DESCRIPTION
## Summary
- add simple ChordPro parser grouping chords into measures
- add basic iReal parser for text charts
- mark ChordPro and iReal importer tasks complete and note MusicXML follow-up

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade8b236d483338667443181deb0dd