### PR TITLE
feat: add MusicXML importer and playback count-in

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -103,7 +103,7 @@ Convenciones: [ ] pendiente · [x] hecho
     13C) iReal
         [x] Importación iReal simple con tests.
     13D) MusicXML
-        [ ] Pendiente.
+        [x] Importación MusicXML simple con tests.
 
 14. Preferencias/Vista
     [ ] Tema, fuentes/tamaños, ♯/♭.
@@ -203,3 +203,5 @@ Criterios de aceptación (15B)
   [x] Indicar en la UI los atajos de teclado para el volumen de los acordes.
   20W) Persistencia de volumen de acordes
   [x] Recordar el volumen de los acordes entre sesiones.
+  20X) Conteo previo a la reproducción
+  [x] Reproducir un conteo (count-in) antes de iniciar la reproducción.

--- a/src/audio/player.test.ts
+++ b/src/audio/player.test.ts
@@ -98,6 +98,31 @@ describe('playChart metronome', () => {
     expect(spy).toHaveBeenCalled();
     expect(spy.mock.calls[0][2]).toBe(0.3);
   });
+
+  it('adds count-in clicks', () => {
+    const chart: Chart = {
+      schemaVersion: 1,
+      title: '',
+      sections: [
+        {
+          name: 'A',
+          measures: [
+            {
+              beats: [
+                { chord: '' },
+                { chord: '' },
+                { chord: '' },
+                { chord: '' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const spy = vi.spyOn(player.internal, 'scheduleClick');
+    player.playChart(chart, 120, true, 1, 1, 2);
+    expect(spy).toHaveBeenCalledTimes(6); // 4 beats + 2 count-in
+  });
 });
 
 describe('master volume', () => {

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -107,11 +107,16 @@ export function playChart(
   metronome = true,
   metronomeVolume = 1,
   chordVol = 1,
+  countIn = 0,
 ) {
   const ctx = getCtx();
   if (ctx.state === 'suspended') void ctx.resume();
   const beatDur = 60 / tempo;
   let time = 0;
+  for (let i = 0; i < countIn; i++) {
+    if (metronome) internal.scheduleClick(time, i === 0, metronomeVolume);
+    time += beatDur;
+  }
   chart.sections.forEach((section) => {
     section.measures.forEach((m) => {
       m.beats.forEach((b, i) => {
@@ -133,6 +138,7 @@ export function playSectionLoop(
   metronome = true,
   metronomeVolume = 1,
   chordVol = 1,
+  countIn = 0,
 ) {
   const section = chart.sections[sectionIndex];
   if (!section) return;
@@ -140,9 +146,9 @@ export function playSectionLoop(
     ...chart,
     sections: [section],
   };
-  playChart(subChart, tempo, metronome, metronomeVolume, chordVol);
+  playChart(subChart, tempo, metronome, metronomeVolume, chordVol, countIn);
   const beats = section.measures.reduce((sum, m) => sum + m.beats.length, 0);
-  const duration = (60 / tempo) * beats;
+  const duration = (60 / tempo) * (beats + countIn);
   loopTimeout = setTimeout(
     () =>
       playSectionLoop(
@@ -152,6 +158,7 @@ export function playSectionLoop(
         metronome,
         metronomeVolume,
         chordVol,
+        0,
       ),
     duration * 1000,
   );

--- a/src/importers/musicxml.test.ts
+++ b/src/importers/musicxml.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { parseMusicXML } from './musicxml';
+
+describe('MusicXML importer', () => {
+  it('parses title and chords', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <work><work-title>My Song</work-title></work>
+  <part-list><score-part id="P1"><part-name>Music</part-name></score-part></part-list>
+  <part id="P1">
+    <measure number="1">
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <harmony>
+        <root><root-step>F</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+    </measure>
+    <measure number="2">
+      <harmony>
+        <root><root-step>D</root-step></root>
+        <kind text="m">minor</kind>
+      </harmony>
+      <harmony>
+        <root><root-step>G</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <harmony>
+        <root><root-step>C</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+      <harmony>
+        <root><root-step>F</root-step></root>
+        <kind text="">major</kind>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>`;
+    const chart = parseMusicXML(xml);
+    expect(chart.title).toBe('My Song');
+    expect(chart.sections[0].measures[0].beats[1].chord).toBe('F');
+    expect(chart.sections[0].measures[1].beats[0].chord).toBe('Dm');
+  });
+});

--- a/src/importers/musicxml.ts
+++ b/src/importers/musicxml.ts
@@ -1,0 +1,40 @@
+import { JSDOM } from 'jsdom';
+import type { BeatSlot, Chart, Measure } from '../core/model';
+
+/**
+ * Parse a very small subset of MusicXML into a Chart.
+ * It reads work title and harmony elements assuming 4/4 time
+ * with up to four chords per measure.
+ */
+export function parseMusicXML(input: string): Chart {
+  const doc = new JSDOM(input, { contentType: 'text/xml' }).window.document;
+  const title =
+    doc.getElementsByTagName('work-title')[0]?.textContent?.trim() ?? '';
+
+  const measures: Measure[] = [];
+  doc.querySelectorAll('measure').forEach((m) => {
+    const beats: BeatSlot[] = [];
+    m.querySelectorAll('harmony').forEach((h) => {
+      if (beats.length >= 4) return;
+      const rootStep = h.querySelector('root-step')?.textContent?.trim() ?? '';
+      const alter = h.querySelector('root-alter')?.textContent?.trim();
+      let root = rootStep;
+      if (alter === '1') root += '#';
+      else if (alter === '-1') root += 'b';
+      const kindEl = h.querySelector('kind');
+      const kind =
+        kindEl?.getAttribute('text')?.trim() ??
+        kindEl?.textContent?.trim() ??
+        '';
+      beats.push({ chord: `${root}${kind}` });
+    });
+    while (beats.length < 4) beats.push({ chord: '' });
+    measures.push({ beats });
+  });
+
+  return {
+    schemaVersion: 1,
+    title,
+    sections: [{ name: 'A', measures }],
+  };
+}


### PR DESCRIPTION
## Summary
- parse MusicXML charts into the app's chart model
- add optional count-in before playback and looping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae118f647c8333ab7174edfba84e69