### PR TITLE
feat: add theme and font-size preferences with tests

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -106,7 +106,11 @@ Convenciones: [ ] pendiente · [x] hecho
         [x] Importación MusicXML simple con tests.
 
 14. Preferencias/Vista
-    [ ] Tema, fuentes/tamaños, ♯/♭.
+    [x] Tema, fuentes/tamaños, ♯/♭.
+    14B) Pruebas automáticas de preferencias
+        [x] Hecho.
+    14C) Detección automática de tema del sistema
+        [ ] Pendiente.
 
 15. PWA / Offline
     [ ] Service Worker + manifest; app shell offline; onLine indicator.

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,13 @@ import { playChart, stopPlayback, isPlaying } from './audio/player';
 const app = document.querySelector<HTMLDivElement>('#app')!;
 app.append(Header(), Rail(), Grid(), Controls());
 
+const applyPrefs = () => {
+  document.body.classList.toggle('dark', store.theme === 'dark');
+  document.body.style.setProperty('--font-size', `${store.fontSize}px`);
+};
+applyPrefs();
+store.subscribe(applyPrefs);
+
 window.addEventListener('keydown', (ev) => {
   if (ev.ctrlKey && ev.altKey && ev.shiftKey && ev.key === 'ArrowUp') {
     const vol = Math.min(1, Math.round((store.chordVolume + 0.1) * 100) / 100);

--- a/src/style.css
+++ b/src/style.css
@@ -1,17 +1,40 @@
+:root {
+  --bg: #fff;
+  --text: #000;
+  --header-bg: #f0f0f0;
+  --header-text: #000;
+  --rail-bg: #ddd;
+  --measure-border: #888;
+  --secondary-color: #555;
+}
+
 body {
   margin: 0;
   font-family: sans-serif;
+  background: var(--bg, #fff);
+  color: var(--text, #000);
+  font-size: var(--font-size, 16px);
+}
+
+body.dark {
+  --bg: #1e1e1e;
+  --text: #fff;
+  --header-bg: #222;
+  --header-text: #fff;
+  --rail-bg: #444;
+  --measure-border: #666;
+  --secondary-color: #bbb;
 }
 
 header {
-  background: #222;
-  color: #fff;
+  background: var(--header-bg, #222);
+  color: var(--header-text, #fff);
   padding: 0.5rem 1rem;
 }
 
 .rail {
   height: 20px;
-  background: #444;
+  background: var(--rail-bg, #444);
 }
 
 .grid {
@@ -32,7 +55,7 @@ header {
 }
 
 .measure {
-  border: 1px solid #888;
+  border: 1px solid var(--measure-border, #888);
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   width: 8rem;
@@ -75,7 +98,7 @@ header {
 }
 
 .slot {
-  border-right: 1px solid #888;
+  border-right: 1px solid var(--measure-border, #888);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -89,7 +112,7 @@ header {
 .secondary {
   font-size: 0.7em;
   line-height: 1;
-  color: #555;
+  color: var(--secondary-color, #555);
 }
 
 .slot:last-child {

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -291,7 +291,9 @@ export function Controls(): HTMLElement {
 
   const instrumentLabel = document.createElement('label');
   instrumentLabel.textContent = 'Vista: ';
+  instrumentLabel.htmlFor = 'instrument-select';
   const instrumentSelect = document.createElement('select');
+  instrumentSelect.id = 'instrument-select';
   [
     ['C', 'Concierto'],
     ['Bb', 'Bb'],
@@ -306,7 +308,9 @@ export function Controls(): HTMLElement {
 
   const accidentalLabel = document.createElement('label');
   accidentalLabel.textContent = 'Preferir: ';
+  accidentalLabel.htmlFor = 'accidental-select';
   const accidentalSelect = document.createElement('select');
+  accidentalSelect.id = 'accidental-select';
   [
     ['sharp', '♯'],
     ['flat', '♭'],
@@ -335,6 +339,29 @@ export function Controls(): HTMLElement {
       accidentalSelect.value === 'sharp',
     );
   };
+
+  const themeBtn = document.createElement('button');
+  const updateThemeBtn = () => {
+    themeBtn.textContent =
+      store.theme === 'dark' ? 'Tema claro' : 'Tema oscuro';
+  };
+  updateThemeBtn();
+  themeBtn.onclick = () => {
+    store.toggleTheme();
+  };
+
+  const fontSizeLabel = document.createElement('label');
+  fontSizeLabel.textContent = 'Tamaño fuente: ';
+  const fontSizeInput = document.createElement('input');
+  fontSizeInput.type = 'number';
+  fontSizeInput.min = '12';
+  fontSizeInput.max = '24';
+  fontSizeInput.value = String(store.fontSize);
+  fontSizeInput.onchange = () => {
+    const val = Number(fontSizeInput.value);
+    if (!Number.isNaN(val)) store.setFontSize(val);
+  };
+  fontSizeLabel.appendChild(fontSizeInput);
 
   const voltaLabel = document.createElement('label');
   voltaLabel.textContent = 'Volta: ';
@@ -432,6 +459,8 @@ export function Controls(): HTMLElement {
     masterVolInput.value = String(store.masterVolume);
     chordVolInput.value = String(store.chordVolume);
     chordWaveSelect.value = store.chordWave;
+    updateThemeBtn();
+    fontSizeInput.value = String(store.fontSize);
   });
   updateMarkerSelect();
 
@@ -460,6 +489,8 @@ export function Controls(): HTMLElement {
     instrumentSelect,
     accidentalLabel,
     accidentalSelect,
+    themeBtn,
+    fontSizeLabel,
     voltaLabel,
     clearVoltaBtn,
     markerLabel,

--- a/tests/preferences.spec.ts
+++ b/tests/preferences.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => {
+    window.localStorage.setItem('jaireal.showSecondary', 'true');
+  });
+  await page.reload();
+});
+
+test('toggle theme persists', async ({ page }) => {
+  await page.goto('/');
+  const btn = page.getByRole('button', { name: /tema/i });
+  const initial = await page.evaluate(() =>
+    localStorage.getItem('jaireal.theme'),
+  );
+  await btn.click();
+  await page.waitForFunction(
+    (prev) => localStorage.getItem('jaireal.theme') !== prev,
+    initial,
+  );
+  const toggled = await page.evaluate(() =>
+    localStorage.getItem('jaireal.theme'),
+  );
+  await page.reload();
+  const persisted = await page.evaluate(() =>
+    localStorage.getItem('jaireal.theme'),
+  );
+  expect(persisted).toBe(toggled);
+});
+
+test('prefer accidentals selection persists', async ({ page }) => {
+  await page.goto('/');
+  const select = page.locator('#accidental-select');
+  await expect(select).toHaveValue('sharp');
+  await select.selectOption('flat');
+  await expect(select).toHaveValue('flat');
+  await page.reload();
+  const selectReload = page.locator('#accidental-select');
+  await expect(selectReload).toHaveValue('flat');
+});


### PR DESCRIPTION
## Summary
- add light/dark theme toggle and font-size preference persisted in local storage
- expose theme and font-size controls in UI and apply them on load
- test and document preferences, update tasks list

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ae26fcd738833382ed71f092419a7e