### PR TITLE
Add local chart library and offline support

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -93,7 +93,9 @@ Convenciones: [ ] pendiente · [x] hecho
     [x] Hecho.
 
 12. Biblioteca local
-    [ ] IndexedDB; etiquetas + búsqueda básica.
+    [x] IndexedDB; etiquetas + búsqueda básica.
+    12B) UI de biblioteca mejorada
+    [ ] Mostrar listado de charts con filtros avanzados.
 
 13. Importadores
     13A) CSV básico
@@ -115,7 +117,9 @@ Convenciones: [ ] pendiente · [x] hecho
     [x] Hecho.
 
 15. PWA / Offline
-    [ ] Service Worker + manifest; app shell offline; onLine indicator.
+    [x] Service Worker + manifest; app shell offline; onLine indicator.
+    15C) Estrategia de caché avanzada
+    [ ] cache-first para estáticos y network-first para datos.
 
 15B) Online / Sincronización y Nube
 Objetivo: offline-first con sync en la nube, compartir y backups.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>JaiReal-PRO</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint": "^9.34.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
+        "fake-indexeddb": "^5.0.2",
         "globals": "^16.3.0",
         "jsdom": "^26.1.0",
         "playwright": "^1.55.0",
@@ -2371,6 +2372,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
+      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "fake-indexeddb": "^5.0.2",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
     "playwright": "^1.55.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "JaiReal-PRO",
+  "short_name": "JaiReal",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Editor de cifrados offline",
+  "icons": [
+    {
+      "src": "/vite.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,12 @@
+/* eslint-env serviceworker */
+/* eslint-disable no-undef */
+const CACHE = 'jaireal-cache-v1';
+const ASSETS = ['/', '/index.html'];
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(ASSETS)));
+});
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((res) => res || fetch(event.request)),
+  );
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,14 @@ import { playChart, stopPlayback, isPlaying } from './audio/player';
 const app = document.querySelector<HTMLDivElement>('#app')!;
 app.append(Header(), Rail(), Grid(), Controls());
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {
+      // ignore
+    });
+  });
+}
+
 const applyPrefs = () => {
   document.body.classList.toggle('dark', store.theme === 'dark');
   document.body.style.setProperty('--font-size', `${store.fontSize}px`);

--- a/src/state/library.test.ts
+++ b/src/state/library.test.ts
@@ -1,0 +1,50 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveChart, listCharts, getChart } from './library';
+import { schemaVersion, type Chart } from '../core/model';
+
+function sampleChart(title: string): Chart {
+  return {
+    schemaVersion,
+    title,
+    sections: [
+      {
+        name: 'A',
+        measures: [
+          {
+            beats: [{ chord: '' }, { chord: '' }, { chord: '' }, { chord: '' }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('library', () => {
+  beforeEach(() => {
+    return new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase('jaireal-library');
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  });
+  it('saves and retrieves chart', async () => {
+    const id = await saveChart(sampleChart('Test'), 'Test', ['jazz']);
+    const charts = await listCharts();
+    expect(charts).toHaveLength(1);
+    expect(charts[0].title).toBe('Test');
+    const chart = await getChart(id);
+    expect(chart?.title).toBe('Test');
+  });
+
+  it('searches by title and tags', async () => {
+    await saveChart(sampleChart('Blues'), 'Blues', ['jazz']);
+    await saveChart(sampleChart('Rock Song'), 'Rock Song', ['rock']);
+    const byTag = await listCharts('jazz');
+    expect(byTag).toHaveLength(1);
+    expect(byTag[0].title).toBe('Blues');
+    const byTitle = await listCharts('rock');
+    expect(byTitle).toHaveLength(1);
+    expect(byTitle[0].title).toBe('Rock Song');
+  });
+});

--- a/src/state/library.ts
+++ b/src/state/library.ts
@@ -1,0 +1,93 @@
+import type { Chart } from '../core/model';
+
+const DB_NAME = 'jaireal-library';
+const STORE_NAME = 'charts';
+
+interface LibraryItem {
+  id: string;
+  title: string;
+  tags: string[];
+  chart: Chart;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      store.createIndex('title', 'title', { unique: false });
+      store.createIndex('tags', 'tags', { unique: false, multiEntry: true });
+    };
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+export async function saveChart(
+  chart: Chart,
+  title: string,
+  tags: string[],
+  id?: string,
+): Promise<string> {
+  const db = await openDB();
+  const chartId = id ?? crypto.randomUUID();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  store.put({ id: chartId, title, tags, chart });
+  await new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(undefined);
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+  return chartId;
+}
+
+export async function getChart(id: string): Promise<Chart | undefined> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const store = tx.objectStore(STORE_NAME);
+  const req = store.get(id);
+  const item = await new Promise<LibraryItem | undefined>((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result as LibraryItem | undefined);
+    req.onerror = () => reject(req.error);
+  });
+  db.close();
+  return item?.chart;
+}
+
+export async function listCharts(
+  query?: string,
+): Promise<Array<{ id: string; title: string; tags: string[] }>> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const store = tx.objectStore(STORE_NAME);
+  const req = store.getAll();
+  const items = await new Promise<LibraryItem[]>((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result as LibraryItem[]);
+    req.onerror = () => reject(req.error);
+  });
+  db.close();
+  if (!query) {
+    return items.map(({ id, title, tags }) => ({ id, title, tags }));
+  }
+  const q = query.toLowerCase();
+  return items
+    .filter(
+      (it) =>
+        it.title.toLowerCase().includes(q) ||
+        it.tags.some((t) => t.toLowerCase().includes(q)),
+    )
+    .map(({ id, title, tags }) => ({ id, title, tags }));
+}
+
+export async function deleteChart(id: string): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  tx.objectStore(STORE_NAME).delete(id);
+  await new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve(undefined);
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
+}

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,11 @@ header {
   padding: 0.5rem 1rem;
 }
 
+.net-status {
+  margin-left: 1rem;
+  font-size: 0.9rem;
+}
+
 .rail {
   height: 20px;
   background: var(--rail-bg, #444);

--- a/src/ui/components/Header.ts
+++ b/src/ui/components/Header.ts
@@ -1,5 +1,15 @@
 export function Header(): HTMLElement {
   const el = document.createElement('header');
-  el.textContent = 'JaiReal-PRO';
+  const title = document.createElement('span');
+  title.textContent = 'JaiReal-PRO';
+  const status = document.createElement('span');
+  status.className = 'net-status';
+  const update = () => {
+    status.textContent = navigator.onLine ? 'En línea' : 'Sin conexión';
+  };
+  window.addEventListener('online', update);
+  window.addEventListener('offline', update);
+  update();
+  el.append(title, status);
   return el;
 }


### PR DESCRIPTION
## Summary
- implement IndexedDB-backed library with tag search and tests
- enable PWA offline with manifest, service worker, and online status indicator
- update task checklist and add future improvements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae2bf798448333b7a898c9767f242e