### PR TITLE
feat: improve library UI and offline caching

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -95,7 +95,9 @@ Convenciones: [ ] pendiente · [x] hecho
 12. Biblioteca local
     [x] IndexedDB; etiquetas + búsqueda básica.
     12B) UI de biblioteca mejorada
-    [ ] Mostrar listado de charts con filtros avanzados.
+    [x] Mostrar listado de charts con filtros avanzados.
+    12C) Ordenar biblioteca por título
+    [ ] Permitir ordenar la lista de charts alfabéticamente.
 
 13. Importadores
     13A) CSV básico
@@ -119,7 +121,9 @@ Convenciones: [ ] pendiente · [x] hecho
 15. PWA / Offline
     [x] Service Worker + manifest; app shell offline; onLine indicator.
     15C) Estrategia de caché avanzada
-    [ ] cache-first para estáticos y network-first para datos.
+    [x] cache-first para estáticos y network-first para datos.
+    15D) Limpieza de caché obsoleta
+    [ ] Eliminar versiones antiguas de caché al activar el Service Worker.
 
 15B) Online / Sincronización y Nube
 Objetivo: offline-first con sync en la nube, compartir y backups.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,37 @@
 /* eslint-env serviceworker */
 /* eslint-disable no-undef */
-const CACHE = 'jaireal-cache-v1';
+const STATIC_CACHE = 'jaireal-static-v1';
+const DATA_CACHE = 'jaireal-data-v1';
 const ASSETS = ['/', '/index.html'];
 self.addEventListener('install', (event) => {
-  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(ASSETS)));
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(ASSETS)),
+  );
 });
 self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+  const url = new URL(request.url);
+  if (url.origin === self.location.origin && url.pathname.startsWith('/api/')) {
+    event.respondWith(
+      fetch(request)
+        .then((res) => {
+          const copy = res.clone();
+          caches.open(DATA_CACHE).then((cache) => cache.put(request, copy));
+          return res;
+        })
+        .catch(() => caches.match(request)),
+    );
+    return;
+  }
   event.respondWith(
-    caches.match(event.request).then((res) => res || fetch(event.request)),
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request).then((res) => {
+        const copy = res.clone();
+        caches.open(STATIC_CACHE).then((cache) => cache.put(request, copy));
+        return res;
+      });
+    }),
   );
 });

--- a/src/state/library.test.ts
+++ b/src/state/library.test.ts
@@ -40,11 +40,19 @@ describe('library', () => {
   it('searches by title and tags', async () => {
     await saveChart(sampleChart('Blues'), 'Blues', ['jazz']);
     await saveChart(sampleChart('Rock Song'), 'Rock Song', ['rock']);
-    const byTag = await listCharts('jazz');
+    const byTag = await listCharts({ tag: 'jazz' });
     expect(byTag).toHaveLength(1);
     expect(byTag[0].title).toBe('Blues');
-    const byTitle = await listCharts('rock');
+    const byTitle = await listCharts({ title: 'rock' });
     expect(byTitle).toHaveLength(1);
     expect(byTitle[0].title).toBe('Rock Song');
+  });
+
+  it('filters by title and tag simultaneously', async () => {
+    await saveChart(sampleChart('Jazz Rock'), 'Jazz Rock', ['jazz', 'rock']);
+    await saveChart(sampleChart('Jazz Blues'), 'Jazz Blues', ['jazz']);
+    const filtered = await listCharts({ title: 'jazz', tag: 'rock' });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].title).toBe('Jazz Rock');
   });
 });

--- a/src/style.css
+++ b/src/style.css
@@ -160,3 +160,40 @@ header {
     color: #000;
   }
 }
+
+.library-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.library-modal-content {
+  background: var(--bg, #fff);
+  color: var(--text, #000);
+  padding: 1rem;
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.library-modal label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.library-modal ul {
+  list-style: none;
+  padding: 0;
+  max-height: 50vh;
+  overflow: auto;
+}
+
+.library-modal li {
+  margin: 0.25rem 0;
+}

--- a/src/ui/components/Controls.ts
+++ b/src/ui/components/Controls.ts
@@ -10,9 +10,9 @@ import { exportChartPDF } from '../../export/pdf';
 import { getTemplate, type TemplateName } from '../../core/templates';
 import {
   saveChart as saveLibraryChart,
-  listCharts as listLibraryCharts,
   getChart as getLibraryChart,
 } from '../../state/library';
+import { LibraryModal } from './LibraryModal';
 
 type WaveType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -98,23 +98,14 @@ export function Controls(): HTMLElement {
 
   const openLibBtn = document.createElement('button');
   openLibBtn.textContent = 'Abrir de biblioteca';
-  openLibBtn.onclick = async () => {
-    const query = prompt('Buscar');
-    const charts = await listLibraryCharts(query ?? undefined);
-    if (charts.length === 0) {
-      alert('No encontrado');
-      return;
-    }
-    const choices = charts.map((c, i) => `${i + 1}: ${c.title}`).join('\n');
-    const sel = prompt(`Elige chart:\n${choices}`);
-    const idx = sel ? Number(sel) - 1 : -1;
-    const item = charts[idx];
-    if (item) {
-      const chart = await getLibraryChart(item.id);
+  openLibBtn.onclick = () => {
+    const modal = LibraryModal(async (id) => {
+      const chart = await getLibraryChart(id);
       if (chart) {
         store.setChart(chart);
       }
-    }
+    });
+    document.body.appendChild(modal);
   };
 
   const templateLabel = document.createElement('label');

--- a/src/ui/components/LibraryModal.ts
+++ b/src/ui/components/LibraryModal.ts
@@ -1,0 +1,54 @@
+import { listCharts as listLibraryCharts } from '../../state/library';
+
+export function LibraryModal(onSelect: (id: string) => void): HTMLElement {
+  const overlay = document.createElement('div');
+  overlay.className = 'library-modal';
+
+  const content = document.createElement('div');
+  content.className = 'library-modal-content';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = 'Cerrar';
+  closeBtn.type = 'button';
+  closeBtn.onclick = () => overlay.remove();
+
+  const titleLabel = document.createElement('label');
+  titleLabel.textContent = 'Título:';
+  const titleInput = document.createElement('input');
+  titleLabel.appendChild(titleInput);
+
+  const tagLabel = document.createElement('label');
+  tagLabel.textContent = 'Etiqueta:';
+  const tagInput = document.createElement('input');
+  tagLabel.appendChild(tagInput);
+
+  const list = document.createElement('ul');
+
+  async function refresh() {
+    const charts = await listLibraryCharts({
+      title: titleInput.value || undefined,
+      tag: tagInput.value || undefined,
+    });
+    list.innerHTML = '';
+    charts.forEach((c) => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = `${c.title} [${c.tags.join(', ')}]`;
+      btn.onclick = () => {
+        onSelect(c.id);
+        overlay.remove();
+      };
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  }
+
+  titleInput.addEventListener('input', refresh);
+  tagInput.addEventListener('input', refresh);
+  refresh();
+
+  content.append(closeBtn, titleLabel, tagLabel, list);
+  overlay.appendChild(content);
+  return overlay;
+}


### PR DESCRIPTION
## Summary
- add modal to browse library with title and tag filters
- support filtered list in library state API
- implement cache-first and network-first strategies in service worker

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` (fails: homepage has header, measure has four editable slots, toggle secondary line with keyboard shortcut, adjust chord volume with keyboard shortcuts, export chart to PDF, reset master volume with keyboard shortcut, adjust master volume with keyboard shortcuts, close marker validation message manually, adjust metronome volume with keyboard shortcuts, toggle theme persists, auto-detects system theme, prefer accidentals selection persists, adjust tempo with keyboard shortcuts, adjust tempo with mouse wheel, shows octave transpose shortcuts in controls, transpose with keyboard shortcuts)

------
https://chatgpt.com/codex/tasks/task_e_68ae2e2388bc8333b6c558d05079c128