### PR TITLE
feat: sort library charts and clean caches

### DIFF
--- a/AGENTS_tareas.md
+++ b/AGENTS_tareas.md
@@ -97,7 +97,7 @@ Convenciones: [ ] pendiente · [x] hecho
     12B) UI de biblioteca mejorada
     [x] Mostrar listado de charts con filtros avanzados.
     12C) Ordenar biblioteca por título
-    [ ] Permitir ordenar la lista de charts alfabéticamente.
+    [x] Permitir ordenar la lista de charts alfabéticamente.
 
 13. Importadores
     13A) CSV básico
@@ -123,7 +123,7 @@ Convenciones: [ ] pendiente · [x] hecho
     15C) Estrategia de caché avanzada
     [x] cache-first para estáticos y network-first para datos.
     15D) Limpieza de caché obsoleta
-    [ ] Eliminar versiones antiguas de caché al activar el Service Worker.
+    [x] Eliminar versiones antiguas de caché al activar el Service Worker.
 
 15B) Online / Sincronización y Nube
 Objetivo: offline-first con sync en la nube, compartir y backups.
@@ -163,7 +163,9 @@ Criterios de aceptación (15B)
     [x] Establecer lang="es".
 
 17. QA/E2E
-    [ ] Vitest (modelo/transpose/parsers); Playwright (MVP y flujos online); CI artefactos.
+    [x] Vitest (modelo/transpose/parsers); Playwright (MVP y flujos online); CI artefactos.
+    17B) Instalación automática de navegadores Playwright
+    [x] Descargar navegadores antes de ejecutar pruebas e2e.
 
 18. Estándares
     [ ] TS estricto, lógica pura en core, sin innerHTML, eventos delegados, Conventional Commits.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright install && playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,6 +8,17 @@ self.addEventListener('install', (event) => {
     caches.open(STATIC_CACHE).then((cache) => cache.addAll(ASSETS)),
   );
 });
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== STATIC_CACHE && k !== DATA_CACHE)
+          .map((k) => caches.delete(k)),
+      ),
+    ),
+  );
+});
 self.addEventListener('fetch', (event) => {
   const { request } = event;
   if (request.method !== 'GET') return;

--- a/src/state/library.test.ts
+++ b/src/state/library.test.ts
@@ -55,4 +55,11 @@ describe('library', () => {
     expect(filtered).toHaveLength(1);
     expect(filtered[0].title).toBe('Jazz Rock');
   });
+
+  it('lists charts sorted by title', async () => {
+    await saveChart(sampleChart('B Song'), 'B Song', []);
+    await saveChart(sampleChart('A Song'), 'A Song', []);
+    const charts = await listCharts();
+    expect(charts.map((c) => c.title)).toEqual(['A Song', 'B Song']);
+  });
 });

--- a/src/state/library.ts
+++ b/src/state/library.ts
@@ -73,20 +73,22 @@ export async function listCharts(
     req.onerror = () => reject(req.error);
   });
   db.close();
-  if (!filters) {
-    return items.map(({ id, title, tags }) => ({ id, title, tags }));
-  }
-  const title = filters.title?.toLowerCase();
-  const tag = filters.tag?.toLowerCase();
-  return items
-    .filter((it) => {
+  let filtered: LibraryItem[] = items;
+  if (filters) {
+    const title = filters.title?.toLowerCase();
+    const tag = filters.tag?.toLowerCase();
+    filtered = filtered.filter((it) => {
       const matchTitle = title ? it.title.toLowerCase().includes(title) : true;
       const matchTag = tag
         ? it.tags.some((t) => t.toLowerCase().includes(tag))
         : true;
       return matchTitle && matchTag;
-    })
-    .map(({ id, title, tags }) => ({ id, title, tags }));
+    });
+  }
+  filtered.sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }),
+  );
+  return filtered.map(({ id, title, tags }) => ({ id, title, tags }));
 }
 
 export async function deleteChart(id: string): Promise<void> {

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -9,7 +9,7 @@ test.beforeEach(async ({ context }) => {
 
 test('homepage has header', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('header')).toHaveText('JaiReal-PRO');
+  await expect(page.locator('header')).toContainText('JaiReal-PRO');
 });
 
 test('measure has four editable slots', async ({ page }) => {


### PR DESCRIPTION
## Summary
- sort library listings alphabetically
- remove outdated caches on service worker activation
- ensure Playwright browsers are installed before running e2e tests
- relax header assertion to account for online indicator

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ae2fb3e40c8333be9924697f1daaeb