### PR TITLE
feat(auth): add basic authentication utilities

### DIFF
--- a/src/state/auth.test.ts
+++ b/src/state/auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import type { User } from '@supabase/supabase-js';
+
+vi.mock('./supabase', () => {
+  const signInWithOtp = vi.fn().mockResolvedValue({ error: null });
+  const signInWithOAuth = vi.fn().mockResolvedValue({ error: null });
+  const signOut = vi.fn().mockResolvedValue({ error: null });
+  const onAuthStateChange = vi.fn();
+  return {
+    supabase: {
+      auth: { signInWithOtp, signInWithOAuth, signOut, onAuthStateChange },
+    },
+  };
+});
+
+import { supabase } from './supabase';
+import {
+  signInWithEmail,
+  signInWithGoogle,
+  signOut,
+  onAuthChange,
+} from './auth';
+
+describe('auth', () => {
+  it('signInWithEmail calls supabase', async () => {
+    await signInWithEmail('test@example.com');
+    expect(supabase.auth.signInWithOtp).toHaveBeenCalledWith({
+      email: 'test@example.com',
+    });
+  });
+
+  it('signInWithGoogle uses OAuth provider', async () => {
+    await signInWithGoogle();
+    expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+    });
+  });
+
+  it('signOut delegates to supabase', async () => {
+    await signOut();
+    expect(supabase.auth.signOut).toHaveBeenCalled();
+  });
+
+  it('onAuthChange passes user from session', () => {
+    const callback = vi.fn();
+    let storedCallback:
+      | ((event: string, session: { user: User } | null) => void)
+      | undefined;
+    const onAuthStateChangeMock = supabase.auth
+      .onAuthStateChange as unknown as Mock;
+    onAuthStateChangeMock.mockImplementation((cb: typeof storedCallback) => {
+      storedCallback = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+    onAuthChange(callback);
+    const fakeUser = { id: '1' } as unknown as User;
+    storedCallback?.('SIGNED_IN', { user: fakeUser });
+    expect(callback).toHaveBeenCalledWith(fakeUser);
+    storedCallback?.('SIGNED_OUT', null);
+    expect(callback).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/state/auth.ts
+++ b/src/state/auth.ts
@@ -1,0 +1,36 @@
+import type { User } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+/**
+ * Sign in using a magic link sent to the provided email.
+ */
+export async function signInWithEmail(email: string): Promise<void> {
+  const { error } = await supabase.auth.signInWithOtp({ email });
+  if (error) throw error;
+}
+
+/**
+ * Sign in with Google using Supabase's OAuth flow.
+ */
+export async function signInWithGoogle(): Promise<void> {
+  const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+  if (error) throw error;
+}
+
+/**
+ * Sign out the current user.
+ */
+export async function signOut(): Promise<void> {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+}
+
+/**
+ * Subscribe to authentication state changes. The callback will be invoked
+ * whenever the active session changes.
+ */
+export function onAuthChange(callback: (user: User | null) => void): void {
+  supabase.auth.onAuthStateChange((_event, session) => {
+    callback(session?.user ?? null);
+  });
+}


### PR DESCRIPTION
## Summary
- add auth helpers for email, Google login and sign out
- expose auth state change listener
- test auth helpers

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*


------
https://chatgpt.com/codex/tasks/task_e_68ae4978ce308333a3bf783e445e173b